### PR TITLE
More refactoring: Move Kafka configuration interfaces, some code into…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 # haystack-pipes
 Packages to send ("pipe") Haystack data to external sinks (like AWS Firehose)
+![High Level Block Diagram](https://github.com/ExpediaDotCom/haystack-pipes/blob/master/documents/diagrams/haystack_pipes.png)
 
 The haystack-pipes unit delivers a human-friendly version of Haystack messages to zero or more "durable" locations for 
 more permanent storage. Current "plug`in" candidates for such storage include:
-1. [Amazon Kinesis Firehose](https://aws.amazon.com/kinesis/firehose/) is an AWS service that facilitates loading 
+1. [Kafka Producer](https://github.com/ExpediaDotCom/haystack-pipes/tree/master/kafka-producer)
+2. [Amazon Kinesis Firehose](https://aws.amazon.com/kinesis/firehose/) is an AWS service that facilitates loading 
 streaming data into AWS. Note that its 
 [PutRecordBatch API](http://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecordBatch.html) accepts up to
 500 records, with a maximum size of 4 MB for each put request. The plug in will batch the records appropriately.
@@ -19,6 +21,8 @@ The [json-transformer](https://github.com/ExpediaDotCom/haystack-pipes/tree/mast
 lightweight service that uses [Kafka Streams](https://kafka.apache.org/documentation/streams/) to read the protobuf 
 records from Kafka, transform them to JSON, and write them to another topic in Kafka. The plugins will then consume
 from the latter topic, and then write the JSON records just consumed to their destinations.
+
+#### kafka-producer
 
 #### firehose-writer
 

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/Configuration.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/Configuration.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 
 public class Configuration {
     static final String HAYSTACK_GRAPHITE_CONFIG_PREFIX = "haystack.graphite";
+    public static final String HAYSTACK_KAFKA_CONFIG_PREFIX = "haystack.kafka";
 
     public ConfigurationProvider createMergeConfigurationProvider() {
         final MergeConfigurationSource configurationSource = new MergeConfigurationSource(

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/IntermediateStreamsConfig.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/IntermediateStreamsConfig.java
@@ -14,7 +14,7 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.pipes.jsonTransformer;
+package com.expedia.www.haystack.pipes.commons;
 
 public interface IntermediateStreamsConfig {
     int replicationFactor();

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/KafkaConfig.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/KafkaConfig.java
@@ -14,7 +14,7 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.pipes.jsonTransformer;
+package com.expedia.www.haystack.pipes.commons;
 
 public interface KafkaConfig {
     String brokers();

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/SystemExitUncaughtExceptionHandler.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/SystemExitUncaughtExceptionHandler.java
@@ -14,7 +14,7 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.pipes.jsonTransformer;
+package com.expedia.www.haystack.pipes.commons;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/SystemExitUncaughtExceptionHandlerTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/SystemExitUncaughtExceptionHandlerTest.java
@@ -14,9 +14,9 @@
  *       limitations under the License.
  *
  */
-package com.expedia.www.haystack.pipes.jsonTransformer;
+package com.expedia.www.haystack.pipes.commons;
 
-import com.expedia.www.haystack.pipes.jsonTransformer.SystemExitUncaughtExceptionHandler.Factory;
+import com.expedia.www.haystack.pipes.commons.SystemExitUncaughtExceptionHandler.Factory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,8 +25,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
-import static com.expedia.www.haystack.pipes.jsonTransformer.SystemExitUncaughtExceptionHandler.ERROR_MSG;
-import static com.expedia.www.haystack.pipes.jsonTransformer.SystemExitUncaughtExceptionHandler.SYSTEM_EXIT_STATUS;
+import static com.expedia.www.haystack.pipes.commons.SystemExitUncaughtExceptionHandler.ERROR_MSG;
+import static com.expedia.www.haystack.pipes.commons.SystemExitUncaughtExceptionHandler.SYSTEM_EXIT_STATUS;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;

--- a/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformer.java
+++ b/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformer.java
@@ -18,8 +18,10 @@ package com.expedia.www.haystack.pipes.jsonTransformer;
 
 import com.expedia.open.tracing.Span;
 import com.expedia.www.haystack.pipes.commons.Configuration;
+import com.expedia.www.haystack.pipes.commons.IntermediateStreamsConfig;
+import com.expedia.www.haystack.pipes.commons.KafkaConfig;
 import com.expedia.www.haystack.pipes.commons.Metrics;
-import org.apache.commons.text.StrSubstitutor;
+import com.expedia.www.haystack.pipes.commons.SystemExitUncaughtExceptionHandler;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -99,7 +101,7 @@ public class ProtobufToJsonTransformer {
 
     private static String getKafkaIpAnPort() {
         final KafkaConfig kafkaConfig = getKafkaConfig();
-        return StrSubstitutor.replaceSystemProperties(kafkaConfig.brokers()) + ":" + kafkaConfig.port();
+        return kafkaConfig.brokers() + ":" + kafkaConfig.port();
     }
     
     static String getFromTopic() {
@@ -111,7 +113,7 @@ public class ProtobufToJsonTransformer {
     }
 
     private static KafkaConfig getKafkaConfig() {
-        return CONFIGURATION_PROVIDER.bind("haystack.kafka", KafkaConfig.class);
+        return CONFIGURATION_PROVIDER.bind(Configuration.HAYSTACK_KAFKA_CONFIG_PREFIX, KafkaConfig.class);
     }
 
     private static int getReplicationFactor() {

--- a/json-transformer/src/test/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformerTest.java
+++ b/json-transformer/src/test/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformerTest.java
@@ -17,6 +17,7 @@
 package com.expedia.www.haystack.pipes.jsonTransformer;
 
 import com.expedia.open.tracing.Span;
+import com.expedia.www.haystack.pipes.commons.SystemExitUncaughtExceptionHandler;
 import com.expedia.www.haystack.pipes.jsonTransformer.ProtobufToJsonTransformer.Factory;
 import com.netflix.servo.publish.PollScheduler;
 import org.apache.kafka.clients.consumer.ConsumerConfig;

--- a/kafka-producer/pom.xml
+++ b/kafka-producer/pom.xml
@@ -16,6 +16,7 @@
         <start-class>com.expedia.www.haystack.pipes.kafkaProducer.JsonToKafkaProducer</start-class>
         <!-- Versions -->
         <haystack-pipes-commons-version>1.0-SNAPSHOT</haystack-pipes-commons-version>
+        <kafka-version>0.10.2.1</kafka-version>
     </properties>
 
     <dependencies>
@@ -23,6 +24,11 @@
             <groupId>com.expedia.www</groupId>
             <artifactId>haystack-pipes-commons</artifactId>
             <version>${haystack-pipes-commons-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <version>${kafka-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/JsonToKafkaProducer.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/JsonToKafkaProducer.java
@@ -1,11 +1,104 @@
 package com.expedia.www.haystack.pipes.kafkaProducer;
 
 import com.expedia.www.haystack.pipes.commons.Configuration;
+import com.expedia.www.haystack.pipes.commons.IntermediateStreamsConfig;
+import com.expedia.www.haystack.pipes.commons.KafkaConfig;
+import com.expedia.www.haystack.pipes.commons.SystemExitUncaughtExceptionHandler;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KStreamBuilder;
+import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
 import org.cfg4j.provider.ConfigurationProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
 
 public class JsonToKafkaProducer {
     static final String CLIENT_ID = "haystack-pipes-json-to-kafka-producer";
     static final String STARTED_MSG = "Now started Producer stream to send JSON spans to external Kafka";
     private static final Configuration CONFIGURATION = new Configuration();
     private static final ConfigurationProvider CONFIGURATION_PROVIDER = CONFIGURATION.createMergeConfigurationProvider();
+    private static final StreamsConfig STREAMS_CONFIG = new StreamsConfig(getProperties());
+    static Factory factory = new Factory(); // will be mocked out in unit tests
+    static Logger logger = LoggerFactory.getLogger(JsonToKafkaProducer.class);
+    static final String KLASS_NAME = JsonToKafkaProducer.class.getName();
+    static final String KLASS_SIMPLE_NAME = JsonToKafkaProducer.class.getSimpleName();
+
+    public static void main(String[] args) {
+        createAndStartStream();
+    }
+
+    private static void createAndStartStream() {
+        final KStreamBuilder kStreamBuilder = factory.createKStreamBuilder();
+        buildStreamTopology(kStreamBuilder);
+        startKafkaStreams(kStreamBuilder);
+    }
+
+    private static void buildStreamTopology(KStreamBuilder kStreamBuilder) {
+        final Serde<String> stringSerde = Serdes.String();
+        final KStream<String, String> stream = kStreamBuilder.stream(stringSerde, stringSerde, getFromTopic());
+        final ForeachAction<String, String> produceIntoExternalKafkaAction = new ProduceIntoExternalKafkaAction();
+        stream.foreach(produceIntoExternalKafkaAction);
+    }
+
+    private static String getKafkaIpAnPort() {
+        final KafkaConfig kafkaConfig = getKafkaConfig();
+        return kafkaConfig.brokers() + ":" + kafkaConfig.port();
+    }
+
+    private static void startKafkaStreams(KStreamBuilder kStreamBuilder) {
+        final KafkaStreams kafkaStreams = factory.createKafkaStreams(kStreamBuilder, STREAMS_CONFIG);
+        final SystemExitUncaughtExceptionHandler closeThenRestartUncaughtExceptionHandler
+                = factory.createSystemExitUncaughtExceptionHandler();
+        kafkaStreams.setUncaughtExceptionHandler(closeThenRestartUncaughtExceptionHandler);
+        kafkaStreams.start();
+        logger.info(STARTED_MSG);
+    }
+
+    static Properties getProperties() {
+        final Properties props = new Properties();
+        props.put(StreamsConfig.CLIENT_ID_CONFIG, CLIENT_ID);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, KLASS_NAME);
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, KLASS_SIMPLE_NAME);
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaIpAnPort());
+        props.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, getReplicationFactor());
+        props.put(StreamsConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);
+        return props;
+    }
+
+
+    static String getFromTopic() {
+        return getKafkaConfig().fromTopic();
+    }
+
+    private static KafkaConfig getKafkaConfig() {
+        return CONFIGURATION_PROVIDER.bind(Configuration.HAYSTACK_KAFKA_CONFIG_PREFIX, KafkaConfig.class);
+    }
+
+    private static int getReplicationFactor() {
+        final IntermediateStreamsConfig intermediateStreamsConfig = CONFIGURATION_PROVIDER.bind("haystack.pipe.streams",
+                IntermediateStreamsConfig.class);
+        return intermediateStreamsConfig.replicationFactor();
+    }
+
+    static class Factory {
+        KStreamBuilder createKStreamBuilder() {
+            return new KStreamBuilder();
+        }
+
+        KafkaStreams createKafkaStreams(KStreamBuilder kStreamBuilder, StreamsConfig streamsConfig) {
+            return new KafkaStreams(kStreamBuilder, streamsConfig);
+        }
+
+        SystemExitUncaughtExceptionHandler createSystemExitUncaughtExceptionHandler() {
+            return new SystemExitUncaughtExceptionHandler();
+        }
+
+    }
 }

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
@@ -1,0 +1,9 @@
+package com.expedia.www.haystack.pipes.kafkaProducer;
+
+import org.apache.kafka.streams.kstream.ForeachAction;
+
+public class ProduceIntoExternalKafkaAction implements ForeachAction<String, String> {
+    public void apply(String s, String s2) {
+        // TODO Implement
+    }
+}

--- a/kafka-producer/src/main/resources/base.yaml
+++ b/kafka-producer/src/main/resources/base.yaml
@@ -1,0 +1,14 @@
+haystack:
+  kafka:
+     brokers: "haystack.local" # set in /etc/hosts per instructions in haystack-deployment package
+     port: 9092 # default Kafka port, rarely overridden, but can be overridden by env variable
+     fromTopic: "json-spans"
+  pipe:
+    streams:
+      replicationFactor: 1
+  graphite:
+     prefix: "haystack"
+     address: "haystack.local" # set in /etc/hosts per instructions in haystack-deployment package
+     port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
+     pollIntervalSeconds: 60
+     queueSize: 10


### PR DESCRIPTION
… commons.

Do some copy/paste from json-transformer into kafka-producer;
future refactoring will minimize the amount of duplicated code.
Put the pipes picture in README.md.