### PR TITLE
Add a configuration to control whether or not to wait for the response

### DIFF
--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/Configuration.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/Configuration.java
@@ -14,7 +14,7 @@ public class Configuration {
     static final String HAYSTACK_GRAPHITE_CONFIG_PREFIX = "haystack.graphite";
     static final String HAYSTACK_PIPE_STREAMS = "haystack.pipe.streams";
     static final String HAYSTACK_KAFKA_CONFIG_PREFIX = "haystack.kafka";
-    public static final String HAYSTACK_EXTERNAL_KAFKA_CONFIG_PREFIX = "haystack.externalKafka";
+    public static final String HAYSTACK_EXTERNAL_KAFKA_CONFIG_PREFIX = "haystack.externalkafka";
 
     public ConfigurationProvider createMergeConfigurationProvider() {
         final MergeConfigurationSource configurationSource = new MergeConfigurationSource(

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ExternalKafkaConfig.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ExternalKafkaConfig.java
@@ -21,19 +21,24 @@ package com.expedia.www.haystack.pipes.kafkaProducer;
  * For details on this configurations, see Kafka documentation, e.g.
  * http://kafka.apache.org/documentation.html#producerconfigs,
  * https://kafka.apache.org/0102/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html, etc.
+ * All method names must be lower case and must not include underscores, because the cf4j framework that manages
+ * configuration changes configurations specified by environment variables from upper to lower case and replaces
+ * underscores by periods.
  */
 public interface ExternalKafkaConfig {
     String brokers();
 
     int port();
 
-    String toTopic();
+    String totopic();
 
     String acks(); // "-1": all replicas; "0": don't wait; "1": leader writes to its local log; "all": same as "-1"
 
-    int batchSize();
+    int batchsize();
 
-    int lingerMs();
+    int lingerms();
 
-    int bufferMemory();
+    int buffermemory();
+
+    boolean waitforresponse();
 }

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ExternalKafkaConfigurationProvider.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ExternalKafkaConfigurationProvider.java
@@ -22,12 +22,10 @@ import org.cfg4j.provider.ConfigurationProvider;
 import static com.expedia.www.haystack.pipes.commons.Configuration.HAYSTACK_EXTERNAL_KAFKA_CONFIG_PREFIX;
 
 public class ExternalKafkaConfigurationProvider implements ExternalKafkaConfig {
-    private final ExternalKafkaConfig externalKafkaConfig;
+    private ExternalKafkaConfig externalKafkaConfig;
 
     ExternalKafkaConfigurationProvider() {
-        final Configuration configuration = new Configuration();
-        final ConfigurationProvider configurationProvider = configuration.createMergeConfigurationProvider();
-        externalKafkaConfig = configurationProvider.bind(HAYSTACK_EXTERNAL_KAFKA_CONFIG_PREFIX, ExternalKafkaConfig.class);
+        reload();
     }
 
     @Override
@@ -41,8 +39,8 @@ public class ExternalKafkaConfigurationProvider implements ExternalKafkaConfig {
     }
 
     @Override
-    public String toTopic() {
-        return externalKafkaConfig.toTopic();
+    public String totopic() {
+        return externalKafkaConfig.totopic();
     }
 
     @Override
@@ -51,17 +49,28 @@ public class ExternalKafkaConfigurationProvider implements ExternalKafkaConfig {
     }
 
     @Override
-    public int batchSize() {
-        return externalKafkaConfig.batchSize();
+    public int batchsize() {
+        return externalKafkaConfig.batchsize();
     }
 
     @Override
-    public int lingerMs() {
-        return externalKafkaConfig.lingerMs();
+    public int lingerms() {
+        return externalKafkaConfig.lingerms();
     }
 
     @Override
-    public int bufferMemory() {
-        return externalKafkaConfig.bufferMemory();
+    public int buffermemory() {
+        return externalKafkaConfig.buffermemory();
+    }
+
+    @Override
+    public boolean waitforresponse() {
+        return externalKafkaConfig.waitforresponse();
+    }
+
+    void reload() {
+        final Configuration configuration = new Configuration();
+        final ConfigurationProvider configurationProvider = configuration.createMergeConfigurationProvider();
+        externalKafkaConfig = configurationProvider.bind(HAYSTACK_EXTERNAL_KAFKA_CONFIG_PREFIX, ExternalKafkaConfig.class);
     }
 }

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
@@ -39,8 +39,8 @@ import static com.expedia.www.haystack.pipes.commons.CommonConstants.SUBSYSTEM;
 import static com.expedia.www.haystack.pipes.kafkaProducer.Constants.APPLICATION;
 
 public class ProduceIntoExternalKafkaAction implements ForeachAction<String, String> {
-    private static final ExternalKafkaConfigurationProvider EKCP = new ExternalKafkaConfigurationProvider();
-    private static final String TOPIC = EKCP.toTopic();
+    static final ExternalKafkaConfigurationProvider EKCP = new ExternalKafkaConfigurationProvider();
+    private static final String TOPIC = EKCP.totopic();
     private static final String CLASS_NAME = ProduceIntoExternalKafkaAction.class.getSimpleName();
     private static final MetricObjects METRIC_OBJECTS = new MetricObjects();
     static final String ERROR_MSG = "Problem posting JSON [%s] to Kafka";
@@ -60,9 +60,11 @@ public class ProduceIntoExternalKafkaAction implements ForeachAction<String, Str
         try {
             final ProducerRecord<String, String> producerRecord = factory.createProducerRecord(key, value);
             final Future<RecordMetadata> recordMetadataFuture = kafkaProducer.send(producerRecord);
-            final RecordMetadata recordMetadata = recordMetadataFuture.get();
-            if(logger.isDebugEnabled()) {
-                logger.debug(String.format(DEBUG_MSG, value, recordMetadata.partition()));
+            if(EKCP.waitforresponse()) {
+                final RecordMetadata recordMetadata = recordMetadataFuture.get();
+                if(logger.isDebugEnabled()) {
+                    logger.debug(String.format(DEBUG_MSG, value, recordMetadata.partition()));
+                }
             }
         } catch (Exception exception) {
             ERROR.increment();
@@ -77,9 +79,9 @@ public class ProduceIntoExternalKafkaAction implements ForeachAction<String, Str
         map.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, EKCP.brokers() + ":" + EKCP.port());
         map.put(ProducerConfig.ACKS_CONFIG, EKCP.acks());
         map.put(ProducerConfig.RETRIES_CONFIG, 0);
-        map.put(ProducerConfig.BATCH_SIZE_CONFIG, EKCP.batchSize());
-        map.put(ProducerConfig.LINGER_MS_CONFIG, EKCP.lingerMs());
-        map.put(ProducerConfig.BUFFER_MEMORY_CONFIG, EKCP.bufferMemory());
+        map.put(ProducerConfig.BATCH_SIZE_CONFIG, EKCP.batchsize());
+        map.put(ProducerConfig.LINGER_MS_CONFIG, EKCP.lingerms());
+        map.put(ProducerConfig.BUFFER_MEMORY_CONFIG, EKCP.buffermemory());
         map.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         map.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         return map;

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ExternalKafkaConfigurationProviderTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ExternalKafkaConfigurationProviderTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ExternalKafkaConfigurationProviderTest {
     private ExternalKafkaConfigurationProvider externalKafkaConfigurationProvider;
@@ -41,7 +42,7 @@ public class ExternalKafkaConfigurationProviderTest {
 
     @Test
     public void testToTopic() {
-        assertEquals("externalKafkaTopic", externalKafkaConfigurationProvider.toTopic());
+        assertEquals("externalKafkaTopic", externalKafkaConfigurationProvider.totopic());
     }
 
     @Test
@@ -51,17 +52,22 @@ public class ExternalKafkaConfigurationProviderTest {
 
     @Test
     public void testBatchSize() {
-        assertEquals(8192, externalKafkaConfigurationProvider.batchSize());
+        assertEquals(8192, externalKafkaConfigurationProvider.batchsize());
     }
 
     @Test
     public void testLingerMs() {
-        assertEquals(4, externalKafkaConfigurationProvider.lingerMs());
+        assertEquals(4, externalKafkaConfigurationProvider.lingerms());
     }
 
     @Test
     public void testBufferMemory() {
-        assertEquals(1024, externalKafkaConfigurationProvider.bufferMemory());
+        assertEquals(1024, externalKafkaConfigurationProvider.buffermemory());
+    }
+
+    @Test
+    public void testWaitForResponse() {
+        assertTrue(externalKafkaConfigurationProvider.waitforresponse());
     }
 
 }

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
+import java.lang.reflect.Field;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -145,36 +147,54 @@ public class ProduceIntoExternalKafkaActionTest {
     }
 
     @Test
-    public void testApplySuccessDebugEnabled() throws ExecutionException, InterruptedException {
-        whensForTestApplySuccess(true);
+    public void testApplySuccessDoNotWaitForResponse() throws ExecutionException, InterruptedException {
+        whensForTestApplySuccess(false, false);
 
         produceIntoExternalKafkaAction.apply(KEY, VALUE);
 
         verifyCounters(0);
-        verifiesForTestApplySuccess(true);
+        verifiesForTestApplySuccess(false, true);
     }
 
     @Test
-    public void testApplySuccessDebugDisabled() throws ExecutionException, InterruptedException {
-        whensForTestApplySuccess(false);
+    public void testApplySuccessWaitForResponseDebugEnabled() throws ExecutionException, InterruptedException {
+        whensForTestApplySuccess(true, true);
 
         produceIntoExternalKafkaAction.apply(KEY, VALUE);
 
         verifyCounters(0);
-        verifiesForTestApplySuccess(false);
+        verifiesForTestApplySuccess(true, true);
     }
 
-    private void whensForTestApplySuccess(boolean isDebugEnabled) throws InterruptedException, ExecutionException {
+    @Test
+    public void testApplySuccessWaitForResponseDebugDisabled() throws ExecutionException, InterruptedException {
+        whensForTestApplySuccess(true, false);
+
+        produceIntoExternalKafkaAction.apply(KEY, VALUE);
+
+        verifyCounters(0);
+        verifiesForTestApplySuccess(true, false);
+    }
+
+    private void whensForTestApplySuccess(boolean waitForResponse, boolean isDebugEnabled)
+            throws InterruptedException, ExecutionException {
         whensForTestApply();
-        when(mockLogger.isDebugEnabled()).thenReturn(isDebugEnabled);
-        when(mockRecordMetadataFuture.get()).thenReturn(RECORD_METADATA);
+        if(waitForResponse) {
+            when(mockLogger.isDebugEnabled()).thenReturn(isDebugEnabled);
+            when(mockRecordMetadataFuture.get()).thenReturn(RECORD_METADATA);
+        } else {
+            putWaitForResponseFalseIntoEnvironmentVariables();
+        }
     }
 
-    private void verifiesForTestApplySuccess(boolean isDebugEnabled) throws InterruptedException, ExecutionException {
-        verifiesForTestApply();
-        verify(mockLogger).isDebugEnabled();
-        if(isDebugEnabled) {
-            verify(mockLogger).debug(String.format(DEBUG_MSG, VALUE, PARTITION));
+    private void verifiesForTestApplySuccess(boolean waitForResponse, boolean isDebugEnabled)
+            throws InterruptedException, ExecutionException {
+        verifiesForTestApply(waitForResponse);
+        if(waitForResponse) {
+            verify(mockLogger).isDebugEnabled();
+            if (isDebugEnabled) {
+                verify(mockLogger).debug(String.format(DEBUG_MSG, VALUE, PARTITION));
+            }
         }
     }
 
@@ -187,7 +207,7 @@ public class ProduceIntoExternalKafkaActionTest {
         produceIntoExternalKafkaAction.apply(KEY, VALUE);
 
         verifyCounters(1);
-        verifiesForTestApply();
+        verifiesForTestApply(true);
         verify(mockLogger).error(ERROR_MSG, VALUE, executionException);
     }
 
@@ -197,11 +217,13 @@ public class ProduceIntoExternalKafkaActionTest {
         when(mockKafkaProducer.send(Matchers.any())).thenReturn(mockRecordMetadataFuture);
     }
 
-    private void verifiesForTestApply() throws InterruptedException, ExecutionException {
+    private void verifiesForTestApply(boolean waitForResponse) throws InterruptedException, ExecutionException {
         verify(mockTimer).start();
         verify(mockFactory).createProducerRecord(KEY, VALUE);
         verify(mockKafkaProducer).send(mockProducerRecord);
-        verify(mockRecordMetadataFuture).get();
+        if(waitForResponse) {
+            verify(mockRecordMetadataFuture).get();
+        }
         verify(mockStopwatch).stop();
     }
 
@@ -218,4 +240,23 @@ public class ProduceIntoExternalKafkaActionTest {
         assertEquals(VALUE, producerRecord.value());
     }
 
+    private void putWaitForResponseFalseIntoEnvironmentVariables() {
+        try {
+            final Map<String,String> unmodifiableEnv = System.getenv();
+            final Class<?> cl = unmodifiableEnv.getClass();
+
+            // It is not intended that environment variables be changed after the JVM starts, thus reflection
+            @SuppressWarnings("JavaReflectionMemberAccess")
+            final Field field = cl.getDeclaredField("m");
+            field.setAccessible(true);
+
+            @SuppressWarnings("unchecked")
+            final Map<String,String> modifiableEnv = (Map<String,String>) field.get(unmodifiableEnv);
+            modifiableEnv.put("HAYSTACK_EXTERNALKAFKA_WAITFORRESPONSE", Boolean.FALSE.toString());
+            field.setAccessible(false);
+            ProduceIntoExternalKafkaAction.EKCP.reload();
+        } catch(Exception e) {
+            throw new RuntimeException("Unable to access writable environment variable map.");
+        }
+    }
 }

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
@@ -152,6 +152,7 @@ public class ProduceIntoExternalKafkaActionTest {
 
         produceIntoExternalKafkaAction.apply(KEY, VALUE);
 
+        putWaitForResponseIntoEnvironmentVariables(true); // so that other tests won't see a false
         verifyCounters(0);
         verifiesForTestApplySuccess(false, true);
     }
@@ -183,7 +184,7 @@ public class ProduceIntoExternalKafkaActionTest {
             when(mockLogger.isDebugEnabled()).thenReturn(isDebugEnabled);
             when(mockRecordMetadataFuture.get()).thenReturn(RECORD_METADATA);
         } else {
-            putWaitForResponseFalseIntoEnvironmentVariables();
+            putWaitForResponseIntoEnvironmentVariables(false);
         }
     }
 
@@ -240,7 +241,7 @@ public class ProduceIntoExternalKafkaActionTest {
         assertEquals(VALUE, producerRecord.value());
     }
 
-    private void putWaitForResponseFalseIntoEnvironmentVariables() {
+    private void putWaitForResponseIntoEnvironmentVariables(boolean waitForResponse) {
         try {
             final Map<String,String> unmodifiableEnv = System.getenv();
             final Class<?> cl = unmodifiableEnv.getClass();
@@ -252,7 +253,7 @@ public class ProduceIntoExternalKafkaActionTest {
 
             @SuppressWarnings("unchecked")
             final Map<String,String> modifiableEnv = (Map<String,String>) field.get(unmodifiableEnv);
-            modifiableEnv.put("HAYSTACK_EXTERNALKAFKA_WAITFORRESPONSE", Boolean.FALSE.toString());
+            modifiableEnv.put("HAYSTACK_EXTERNALKAFKA_WAITFORRESPONSE", Boolean.toString(waitForResponse));
             field.setAccessible(false);
             ProduceIntoExternalKafkaAction.EKCP.reload();
         } catch(Exception e) {

--- a/kafka-producer/src/test/resources/base.yaml
+++ b/kafka-producer/src/test/resources/base.yaml
@@ -13,11 +13,12 @@ haystack:
      port: 2003
      pollIntervalSeconds: 60
      queueSize: 10
-  externalKafka:
+  externalkafka:
     brokers: "localhost"
     port: 9093
-    toTopic: "externalKafkaTopic"
+    totopic: "externalKafkaTopic"
     acks: "0"
-    batchSize: 8192
-    lingerMs: 4
-    bufferMemory: 1024
+    batchsize: 8192
+    lingerms: 4
+    buffermemory: 1024
+    waitforresponse: true


### PR DESCRIPTION
from the producer's send() to Kafka.
Make all configurations for ExternalKafkaConfig lower case only so that
they can be overridden by environment variables.