### PR TITLE
Add spring-boot-maven-plug mainClass attribute, needed because the child

### DIFF
--- a/json-transformer/pom.xml
+++ b/json-transformer/pom.xml
@@ -10,10 +10,6 @@
     <name>haystack-pipes-json-transformer</name>
     <url>http://maven.apache.org</url>
 
-    <properties>
-        <start-class>com.expedia.www.haystack.pipes.jsonTransformer.JsonTransformerIsActiveController</start-class>
-    </properties>
-
     <parent>
         <artifactId>haystack-pipes</artifactId>
         <groupId>com.expedia.www</groupId>
@@ -236,6 +232,9 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot-version}</version>
+                <configuration>
+                    <mainClass>com.expedia.www.haystack.pipes.jsonTransformer.JsonTransformerIsActiveController</mainClass>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/kafka-producer/pom.xml
+++ b/kafka-producer/pom.xml
@@ -11,10 +11,6 @@
     <name>haystack-pipes-kafka-producer</name>
     <url>http://maven.apache.org</url>
 
-    <properties>
-        <start-class>com.expedia.www.haystack.pipes.kafkaProducer.KafkaProducerIsActiveController</start-class>
-    </properties>
-
     <parent>
         <artifactId>haystack-pipes</artifactId>
         <groupId>com.expedia.www</groupId>
@@ -153,6 +149,9 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot-version}</version>
+                <configuration>
+                    <mainClass>com.expedia.www.haystack.pipes.kafkaProducer.KafkaProducerIsActiveController</mainClass>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
POMs no longer inherit from the SpringBoot plan.