### PR TITLE
Add and use the logback custom appender in json transformer.

### DIFF
--- a/json-transformer/pom.xml
+++ b/json-transformer/pom.xml
@@ -23,6 +23,11 @@
             <version>${haystack-pipes-commons-version}</version>
         </dependency>
         <dependency>
+            <groupId>com.expedia.www</groupId>
+            <artifactId>haystack-logback-metrics-appender</artifactId>
+            <version>${haystack-logback-metrics-appender-version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.11</artifactId>
             <version>${kafka-version}</version>

--- a/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformer.java
+++ b/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformer.java
@@ -20,7 +20,6 @@ import com.expedia.open.tracing.Span;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaConfigurationProvider;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamBuilder;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter;
-import com.expedia.www.haystack.pipes.commons.Metrics;
 import com.expedia.www.haystack.pipes.commons.serialization.SpanSerdeFactory;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -29,7 +28,6 @@ import org.apache.kafka.streams.kstream.KStreamBuilder;
 
 public class ProtobufToJsonTransformer implements KafkaStreamBuilder {
     static final String CLIENT_ID = "haystack-pipes-protobuf-to-json-transformer";
-    static Metrics metrics = new Metrics();
 
     private static final KafkaConfigurationProvider KAFKA_CONFIGURATION_PROVIDER = new KafkaConfigurationProvider();
 
@@ -50,7 +48,6 @@ public class ProtobufToJsonTransformer implements KafkaStreamBuilder {
      * making it an instance method facilitates unit testing.
      */
     void main() {
-        metrics.startMetricsPolling();
         kafkaStreamStarter.createAndStartStream(this);
     }
 

--- a/json-transformer/src/main/resources/logback.xml
+++ b/json-transformer/src/main/resources/logback.xml
@@ -6,6 +6,10 @@
             <pattern>%d{HH:mm:ss.SSS} %level [%thread] %X{requestid} %logger{10} %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="EmitToGraphiteLogbackAppender"
+              class="com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender">
+        <address>monitoring-influxdb-graphite.kube-system.svc</address>
+    </appender>
     <logger name="com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter" additivity="false" level="INFO">
         <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
     </logger>
@@ -14,5 +18,6 @@
     </logger>
     <root level="WARN">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="EmitToGraphiteLogbackAppender" />
     </root>
 </configuration>

--- a/json-transformer/src/test/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformerTest.java
+++ b/json-transformer/src/test/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformerTest.java
@@ -18,7 +18,6 @@ package com.expedia.www.haystack.pipes.jsonTransformer;
 
 import com.expedia.open.tracing.Span;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter;
-import com.expedia.www.haystack.pipes.commons.Metrics;
 import com.expedia.www.haystack.pipes.commons.serialization.SpanJsonSerializer;
 import com.expedia.www.haystack.pipes.commons.serialization.SpanSerdeFactory;
 import org.apache.kafka.common.serialization.Serde;
@@ -46,10 +45,6 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ProtobufToJsonTransformerTest {
     @Mock
-    private Metrics mockMetrics;
-    private Metrics realMetrics;
-
-    @Mock
     private KafkaStreamStarter mockKafkaStreamStarter;
     @Mock
     private KStreamBuilder mockKStreamBuilder;
@@ -62,15 +57,12 @@ public class ProtobufToJsonTransformerTest {
 
     @Before
     public void setUp() {
-        realMetrics = ProtobufToJsonTransformer.metrics;
-        ProtobufToJsonTransformer.metrics = mockMetrics;
         protobufToJsonTransformer = new ProtobufToJsonTransformer(mockKafkaStreamStarter, new SpanSerdeFactory());
     }
 
     @After
     public void tearDown() {
-        ProtobufToJsonTransformer.metrics = realMetrics;
-        verifyNoMoreInteractions(mockMetrics, mockKafkaStreamStarter, mockKStreamBuilder, mockKStreamStringSpan,
+        verifyNoMoreInteractions(mockKafkaStreamStarter, mockKStreamBuilder, mockKStreamStringSpan,
                 mockKStreamStringSpanJsonSerializer);
     }
 
@@ -86,7 +78,6 @@ public class ProtobufToJsonTransformerTest {
     public void testMain() {
         protobufToJsonTransformer.main();
 
-        verify(mockMetrics).startMetricsPolling();
         verify(mockKafkaStreamStarter).createAndStartStream(protobufToJsonTransformer);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <cfg4j-core-version>4.4.1</cfg4j-core-version>
         <commons-lang3-version>3.7</commons-lang3-version>
         <commons-text-version>1.1</commons-text-version>
-        <haystack-metrics-version>0.2.3</haystack-metrics-version>
-        <haystack-metrics-version>0.2.3</haystack-metrics-version>
+        <haystack-metrics-version>0.2.4</haystack-metrics-version>
+        <haystack-logback-metrics-appender-version>0.1.1</haystack-logback-metrics-appender-version>
         <haystack-pipes-commons-version>1.0-SNAPSHOT</haystack-pipes-commons-version>
         <jacoco-maven-plugin-version>0.7.9</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>


### PR DESCRIPTION
Metrics now starts its own polling, no need to do so in the app.