### PR TITLE
Apply custom appender changes to haystack-pipes-kafka-producer:

### DIFF
--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSource.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSource.java
@@ -69,7 +69,6 @@ public class ChangeEnvVarsToLowerCaseConfigurationSource implements Configuratio
             final String key = (String) next.getKey();
             if (key.startsWith(prefixOfStringsToConvertToLowerCase)) {
                 toAdd.put(key.toLowerCase(), next.getValue());
-                iterator.remove();
             }
         }
         properties.putAll(toAdd);

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
@@ -67,9 +67,8 @@ public class ChangeEnvVarsToLowerCaseConfigurationSourceTest {
     }
 
     private void assertLowerCaseKeyIsPresentInDestination(Properties destination) {
-        final String lowerCaseKey = ppes.entireString.toLowerCase();
-        System.out.println("assertLowerCaseKeyIsPresentInDestination() lowerCaseKey=" + lowerCaseKey);
-        assertTrue(destination.containsKey(lowerCaseKey));
+        final String lowerCaseKey = ppes.entireString.toLowerCase().replace('_', '.');
+        assertTrue("Destination should contain " + lowerCaseKey, destination.containsKey(lowerCaseKey));
     }
 
     private void assertUpperCaseKeyIsStillPresentInDestination(EnvironmentInfo ppes, Properties destination) {

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
@@ -1,7 +1,5 @@
 package com.expedia.www.haystack.pipes.commons;
 
-import com.google.common.collect.MapDifference;
-import com.google.common.collect.Maps;
 import org.cfg4j.source.context.environment.Environment;
 import org.cfg4j.source.context.environment.ImmutableEnvironment;
 import org.cfg4j.source.system.EnvironmentVariablesConfigurationSource;
@@ -23,6 +21,7 @@ import java.util.regex.Pattern;
 import static com.expedia.www.haystack.pipes.commons.ChangeEnvVarsToLowerCaseConfigurationSource.lowerCaseKeysThatStartWithPrefix;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -62,23 +61,24 @@ public class ChangeEnvVarsToLowerCaseConfigurationSourceTest {
 
         verify(mockEnvironmentVariablesConfigurationSource).getConfiguration(ENVIRONMENT);
         verify(mockEnvironmentVariablesConfigurationSource).init();
-        assertSourceSizeIsOneLessThanDestinationSize(ppes, configuration);
+        assertLowerCaseKeyIsPresentInDestination(configuration);
         assertUpperCaseKeyIsStillPresentInDestination(ppes, configuration);
         assertSourceAndDestinationValuesAreEqual(ppes, configuration);
     }
 
-    private void assertSourceSizeIsOneLessThanDestinationSize(EnvironmentInfo source, Properties destination) {
-        final MapDifference<Object, Object> difference = Maps.difference(source.properties, destination);
-        assertEquals(difference.toString(),source.properties.size() + 1, destination.size());
+    private void assertLowerCaseKeyIsPresentInDestination(Properties destination) {
+        final String lowerCaseKey = ppes.entireString.toLowerCase();
+        assertTrue(destination.containsKey(lowerCaseKey));
     }
 
-    private void assertUpperCaseKeyIsStillPresentInDestination(EnvironmentInfo ppes, Properties configuration) {
-        assertNotNull(configuration.getProperty(ppes.entireString));
+    private void assertUpperCaseKeyIsStillPresentInDestination(EnvironmentInfo ppes, Properties destination) {
+        assertNotNull(destination.getProperty(ppes.entireString));
     }
 
-    private void assertSourceAndDestinationValuesAreEqual(EnvironmentInfo ppes, Properties configuration) {
+    private void assertSourceAndDestinationValuesAreEqual(EnvironmentInfo ppes, Properties destination) {
         final String expected = ppes.properties.getProperty(ppes.entireString);
-        final String actual = configuration.getProperty(ppes.entireString.toLowerCase());
+        final String lowerCaseKey = ppes.entireString.toLowerCase();
+        final String actual = destination.getProperty(lowerCaseKey);
         assertEquals(expected, actual);
     }
 

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
@@ -68,6 +68,7 @@ public class ChangeEnvVarsToLowerCaseConfigurationSourceTest {
 
     private void assertLowerCaseKeyIsPresentInDestination(Properties destination) {
         final String lowerCaseKey = ppes.entireString.toLowerCase();
+        System.out.println("assertLowerCaseKeyIsPresentInDestination() lowerCaseKey=" + lowerCaseKey);
         assertTrue(destination.containsKey(lowerCaseKey));
     }
 

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
@@ -68,7 +68,9 @@ public class ChangeEnvVarsToLowerCaseConfigurationSourceTest {
 
     private void assertLowerCaseKeyIsPresentInDestination(Properties destination) {
         final String lowerCaseKey = ppes.entireString.toLowerCase().replace('_', '.');
-        assertTrue("Destination should contain " + lowerCaseKey, destination.containsKey(lowerCaseKey));
+        final String format = "Destination should contain %s; its keys are %s";
+        final String failureMessage = String.format(format, lowerCaseKey, destination.keySet());
+        assertTrue(failureMessage, destination.containsKey(lowerCaseKey));
     }
 
     private void assertUpperCaseKeyIsStillPresentInDestination(EnvironmentInfo ppes, Properties destination) {

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
@@ -1,5 +1,7 @@
 package com.expedia.www.haystack.pipes.commons;
 
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
 import org.cfg4j.source.context.environment.Environment;
 import org.cfg4j.source.context.environment.ImmutableEnvironment;
 import org.cfg4j.source.system.EnvironmentVariablesConfigurationSource;
@@ -66,7 +68,8 @@ public class ChangeEnvVarsToLowerCaseConfigurationSourceTest {
     }
 
     private void assertSourceSizeIsOneLessThanDestinationSize(EnvironmentInfo source, Properties destination) {
-        assertEquals(source.properties.size() + 1, destination.size());
+        final MapDifference<Object, Object> difference = Maps.difference(source.properties, destination);
+        assertEquals(difference.toString(),source.properties.size() + 1, destination.size());
     }
 
     private void assertUpperCaseKeyIsStillPresentInDestination(EnvironmentInfo ppes, Properties configuration) {

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 import static com.expedia.www.haystack.pipes.commons.ChangeEnvVarsToLowerCaseConfigurationSource.lowerCaseKeysThatStartWithPrefix;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -60,17 +60,17 @@ public class ChangeEnvVarsToLowerCaseConfigurationSourceTest {
 
         verify(mockEnvironmentVariablesConfigurationSource).getConfiguration(ENVIRONMENT);
         verify(mockEnvironmentVariablesConfigurationSource).init();
-        assertSourceAndDestinationSizesAreEqual(ppes, configuration);
-        assertUpperCaseKeyIsMissingFromDestination(ppes, configuration);
+        assertSourceSizeIsOneLessThanDestinationSize(ppes, configuration);
+        assertUpperCaseKeyIsStillPresentInDestination(ppes, configuration);
         assertSourceAndDestinationValuesAreEqual(ppes, configuration);
     }
 
-    private void assertSourceAndDestinationSizesAreEqual(EnvironmentInfo ppes, Properties configuration) {
-        assertEquals(ppes.properties.size(), configuration.size());
+    private void assertSourceSizeIsOneLessThanDestinationSize(EnvironmentInfo source, Properties destination) {
+        assertEquals(source.properties.size() + 1, destination.size());
     }
 
-    private void assertUpperCaseKeyIsMissingFromDestination(EnvironmentInfo ppes, Properties configuration) {
-        assertNull(configuration.getProperty(ppes.entireString));
+    private void assertUpperCaseKeyIsStillPresentInDestination(EnvironmentInfo ppes, Properties configuration) {
+        assertNotNull(configuration.getProperty(ppes.entireString));
     }
 
     private void assertSourceAndDestinationValuesAreEqual(EnvironmentInfo ppes, Properties configuration) {
@@ -159,7 +159,7 @@ public class ChangeEnvVarsToLowerCaseConfigurationSourceTest {
 
         final Properties actual = lowerCaseKeysThatStartWithPrefix(properties, prefix);
 
-        assertEquals(2, actual.size());
+        assertEquals(3, actual.size());
         assertEquals(value1, actual.getProperty(matchingKey.toLowerCase()));
         assertEquals(value2, actual.getProperty(nonMatchingKey));
     }

--- a/json-transformer/src/main/resources/logback.xml
+++ b/json-transformer/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
     </appender>
     <appender name="EmitToGraphiteLogbackAppender"
               class="com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender">
-        <address>monitoring-influxdb-graphite.kube-system.svc</address>
+        <address>${HAYSTACK_GRAPHITE_ADDRESS}</address>
     </appender>
     <logger name="com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter" additivity="false" level="INFO">
         <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->

--- a/kafka-producer/pom.xml
+++ b/kafka-producer/pom.xml
@@ -24,6 +24,11 @@
             <version>${haystack-pipes-commons-version}</version>
         </dependency>
         <dependency>
+            <groupId>com.expedia.www</groupId>
+            <artifactId>haystack-logback-metrics-appender</artifactId>
+            <version>${haystack-logback-metrics-appender-version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
             <version>${kafka-version}</version>

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProtobufToKafkaProducer.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProtobufToKafkaProducer.java
@@ -30,7 +30,6 @@ import org.apache.kafka.streams.kstream.KStreamBuilder;
 
 public class ProtobufToKafkaProducer implements KafkaStreamBuilder {
     static final String CLIENT_ID = "haystack-pipes-json-to-kafka-producer";
-    static Metrics metrics = new Metrics();
 
     private static final KafkaConfigurationProvider KAFKA_CONFIGURATION_PROVIDER = new KafkaConfigurationProvider();
     static ProtobufToKafkaProducer instance = new ProtobufToKafkaProducer();
@@ -53,7 +52,6 @@ public class ProtobufToKafkaProducer implements KafkaStreamBuilder {
      * making it an instance method facilitates unit testing.
      */
     void main() {
-        metrics.startMetricsPolling();
         instance.kafkaStreamStarter.createAndStartStream(instance);
     }
 

--- a/kafka-producer/src/main/resources/logback.xml
+++ b/kafka-producer/src/main/resources/logback.xml
@@ -6,10 +6,18 @@
             <pattern>%d{HH:mm:ss.SSS} %level [%thread] %X{requestid} %logger{10} %msg%n</pattern>
         </encoder>
     </appender>
-    <logger name="com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaAction" additivity="false" level="DEBUG">
-        <appender-ref ref="STDOUT" />
+    <appender name="EmitToGraphiteLogbackAppender"
+              class="com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender">
+        <address>${HAYSTACK_GRAPHITE_ADDRESS}</address>
+    </appender>
+    <logger name="com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter" additivity="false" level="INFO">
+        <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
+    </logger>
+    <logger name="com.netflix.servo.publish.graphite.GraphiteMetricObserver" additivity="false" level="INFO">
+        <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
     </logger>
     <root level="WARN">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="EmitToGraphiteLogbackAppender" />
     </root>
 </configuration>

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProtobufToKafkaProducerTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProtobufToKafkaProducerTest.java
@@ -42,9 +42,6 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ProtobufToKafkaProducerTest {
     @Mock
-    private Metrics mockMetrics;
-    private Metrics realMetrics;
-    @Mock
     private ProtobufToKafkaProducer.Factory mockFactory;
     private ProtobufToKafkaProducer.Factory realFactory;
 
@@ -61,8 +58,6 @@ public class ProtobufToKafkaProducerTest {
 
     @Before
     public void setUp() {
-        realMetrics = ProtobufToKafkaProducer.metrics;
-        ProtobufToKafkaProducer.metrics = mockMetrics;
         realFactory = ProtobufToKafkaProducer.factory;
         ProtobufToKafkaProducer.factory = mockFactory;
         protobufToKafkaProducer = new ProtobufToKafkaProducer(mockKafkaStreamStarter, new SpanSerdeFactory());
@@ -70,9 +65,8 @@ public class ProtobufToKafkaProducerTest {
 
     @After
     public void tearDown() {
-        ProtobufToKafkaProducer.metrics = realMetrics;
         ProtobufToKafkaProducer.factory = realFactory;
-        verifyNoMoreInteractions(mockMetrics, mockKStreamBuilder, mockKStream, mockKafkaStreamStarter,
+        verifyNoMoreInteractions(mockKStreamBuilder, mockKStream, mockKafkaStreamStarter,
                 mockProduceIntoExternalKafkaAction);
     }
 
@@ -91,7 +85,6 @@ public class ProtobufToKafkaProducerTest {
 
         protobufToKafkaProducer.main();
 
-        verify(mockMetrics).startMetricsPolling();
         verify(mockKafkaStreamStarter).createAndStartStream(protobufToKafkaProducer);
         ProtobufToKafkaProducer.instance = instanceLoadedByClassLoader;
     }


### PR DESCRIPTION
don't start the metrics polling thread, use custom logback appender.
Also don't remove upper case environment variable after converting
to lower case. This will more easily allow systems that use
haystack-style configurations (lower case, period-delimited) to coexist
in the same JVM with those that use the environment variables directly
(like the logback configurations).