### PR TITLE
Fix two copy/paste errors in which "json-transfomer" was not replaced by

### DIFF
--- a/kafka-producer/build/docker/jmxtrans-agent.xml
+++ b/kafka-producer/build/docker/jmxtrans-agent.xml
@@ -11,7 +11,7 @@
     <outputWriter class="org.jmxtrans.agent.GraphitePlainTextTcpOutputWriter">
         <host>${graphite.host:monitoring-influxdb-graphite.kube-system.svc}</host>
         <port>${graphite.port:2003}</port>
-        <namePrefix>haystack.pipes.json-transformer.#hostname#.</namePrefix>
+        <namePrefix>haystack.pipes.kafka-producer.#hostname#.</namePrefix>
     </outputWriter>
     <collectIntervalInSeconds>30</collectIntervalInSeconds>
 </jmxtrans-agent>

--- a/kafka-producer/src/test/resources/static/index.html
+++ b/kafka-producer/src/test/resources/static/index.html
@@ -3,5 +3,5 @@
     <head>
         <meta charset="UTF-8">
     </head>
-    <body>The json-transformer JVM is running</body>
+    <body>The kafka-producer JVM is running</body>
 </html>


### PR DESCRIPTION
"kafka-producer" when creating the kafka-producer application.