### PR TITLE
Add AddProduceIntoExternalKafkaCallback class; see

### DIFF
--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
@@ -68,7 +68,9 @@ public class ProduceIntoExternalKafkaAction implements ForeachAction<String, Spa
             final String jsonWithOpenTracingTags = printer.print(value);
             jsonWithFlattenedTags = flattenTags(jsonWithOpenTracingTags);
             final ProducerRecord<String, String> producerRecord = factory.createProducerRecord(key, jsonWithFlattenedTags);
-            final Future<RecordMetadata> recordMetadataFuture = kafkaProducer.send(producerRecord);
+            // TODO Use factory to create callback
+            final ProduceIntoExternalKafkaCallback callback = new ProduceIntoExternalKafkaCallback();
+            final Future<RecordMetadata> recordMetadataFuture = kafkaProducer.send(producerRecord, callback);
             if(EKCP.waitforresponse()) {
                 final RecordMetadata recordMetadata = recordMetadataFuture.get();
                 if(logger.isDebugEnabled()) {

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallback.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallback.java
@@ -1,0 +1,29 @@
+package com.expedia.www.haystack.pipes.kafkaProducer;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProduceIntoExternalKafkaCallback implements Callback {
+    static final String DEBUG_MSG = "Successfully posted JSON to Kafka: topic [%s] partition [%d] offset [%d]";
+    static final String ERROR_MSG = "Callback exception posting JSON to Kafka; received message [%s]";
+    static Logger logger = LoggerFactory.getLogger(ProduceIntoExternalKafkaCallback.class);
+
+    @Override
+    public void onCompletion(RecordMetadata metadata, Exception exception) {
+        if(metadata != null) { // means success, per https://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/producer/Callback.html
+            if(logger.isDebugEnabled()) {
+                final String message = String.format(DEBUG_MSG,
+                        metadata.topic(), metadata.partition(), metadata.offset());
+                logger.debug(message);
+            }
+        }
+        if(exception != null) {
+            // Must format below because log4j2 underneath slf4j doesn't handle .error(varargs) properly
+            final String message = String.format(ERROR_MSG, exception.getMessage());
+            logger.error(message, exception);
+        }
+    }
+}

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
@@ -53,7 +53,9 @@ import static com.expedia.www.haystack.pipes.kafkaProducer.TestConstantsAndCommo
 import static com.expedia.www.haystack.pipes.kafkaProducer.TestConstantsAndCommonCode.JSON_SPAN_STRING_WITH_NO_TAGS;
 import static com.expedia.www.haystack.pipes.kafkaProducer.TestConstantsAndCommonCode.NO_TAGS_SPAN;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -251,7 +253,8 @@ public class ProduceIntoExternalKafkaActionTest {
     private void whensForTestApply() {
         when(mockTimer.start()).thenReturn(mockStopwatch);
         when(mockFactory.createProducerRecord(anyString(), anyString())).thenReturn(mockProducerRecord);
-        when(mockKafkaProducer.send(Matchers.any())).thenReturn(mockRecordMetadataFuture);
+        when(mockKafkaProducer.send(any(), any(ProduceIntoExternalKafkaCallback.class)))
+                .thenReturn(mockRecordMetadataFuture);
     }
 
     private void whenForTestApplyAndThrow(Throwable outOfMemoryError) throws InterruptedException, ExecutionException {
@@ -262,7 +265,8 @@ public class ProduceIntoExternalKafkaActionTest {
     private void verifiesForTestApply(boolean waitForResponse, String jsonSpanString) throws InterruptedException, ExecutionException {
         verify(mockTimer).start();
         verify(mockFactory).createProducerRecord(KEY, jsonSpanString);
-        verify(mockKafkaProducer).send(mockProducerRecord);
+        // TODO verify below without any() when the ProduceIntoExternalKafkaCallback object is returned by a factory
+        verify(mockKafkaProducer).send(eq(mockProducerRecord), any(ProduceIntoExternalKafkaCallback.class));
         if(waitForResponse) {
             verify(mockRecordMetadataFuture).get();
         }

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallbackTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallbackTest.java
@@ -1,0 +1,107 @@
+package com.expedia.www.haystack.pipes.kafkaProducer;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import java.util.Random;
+
+import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaCallback.DEBUG_MSG;
+import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaCallback.ERROR_MSG;
+import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaCallback.logger;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProduceIntoExternalKafkaCallbackTest {
+    private final static Random RANDOM = new Random();
+    private final static String TOPIC = RANDOM.nextLong() + "TOPIC";
+    private final static int PARTITION = RANDOM.nextInt();
+    private final static TopicPartition TOPIC_PARTITION = new TopicPartition(TOPIC, PARTITION);
+    private final static long BASE_OFFSET = -1;
+    private final static long RELATIVE_OFFSET = RANDOM.nextLong();
+    private final static long TIMESTAMP = System.currentTimeMillis();
+    private final static long CHECKSUM = RANDOM.nextLong();
+    private final static int SERIALIZED_KEY_SIZE = RANDOM.nextInt();
+    private final static int SERIALIZED_VALUE_SIZE = RANDOM.nextInt();
+    private final static String MESSAGE = RANDOM.nextLong() + "MESSAGE";
+
+    @Mock
+    private Logger mockLogger;
+    private Logger realLogger;
+
+    @Mock
+    private Exception mockException;
+
+    private RecordMetadata recordMetadata;
+    private ProduceIntoExternalKafkaCallback produceIntoExternalKafkaCallback;
+
+    @Before
+    public void setUp() {
+        injectMockAndSaveRealObjects();
+        recordMetadata = new RecordMetadata(TOPIC_PARTITION, BASE_OFFSET, RELATIVE_OFFSET, TIMESTAMP, CHECKSUM,
+                SERIALIZED_KEY_SIZE, SERIALIZED_VALUE_SIZE);
+        produceIntoExternalKafkaCallback = new ProduceIntoExternalKafkaCallback();
+    }
+
+    private void injectMockAndSaveRealObjects() {
+        saveRealAndInjectMockLogger();
+    }
+
+    private void saveRealAndInjectMockLogger() {
+        realLogger = logger;
+        logger = mockLogger;
+    }
+
+    @After
+    public void tearDown() {
+        restoreRealObjects();
+        verifyNoMoreInteractions(mockLogger, mockException);
+    }
+
+    private void restoreRealObjects() {
+        logger = realLogger;
+    }
+
+    @Test
+    public void testOnCompletionBothNull() {
+        produceIntoExternalKafkaCallback.onCompletion(null, null);
+    }
+
+    @Test
+    public void testOnCompletionNonNullMetadataDebugDisabled() {
+        when(mockLogger.isDebugEnabled()).thenReturn(false);
+
+        produceIntoExternalKafkaCallback.onCompletion(recordMetadata, null);
+
+        verify(mockLogger).isDebugEnabled();
+    }
+
+    @Test
+    public void testOnCompletionNonNullMetadataDebugEnabled() {
+        when(mockLogger.isDebugEnabled()).thenReturn(true);
+
+        produceIntoExternalKafkaCallback.onCompletion(recordMetadata, null);
+
+        verify(mockLogger).isDebugEnabled();
+        verify(mockLogger).debug(String.format(DEBUG_MSG, TOPIC, PARTITION, BASE_OFFSET));
+    }
+
+    @Test
+    public void testOneCompletionNonNullException() {
+        when(mockException.getMessage()).thenReturn(MESSAGE);
+
+        produceIntoExternalKafkaCallback.onCompletion(null, mockException);
+
+        verify(mockException).getMessage();
+        verify(mockLogger).error(String.format(ERROR_MSG, MESSAGE), mockException);
+    }
+
+}


### PR DESCRIPTION
https://trello.com/c/h3OUDoAY/166-add-async-callback-to-kafka-producer-send-to-look-for-errors.
This is the first of three commits to fully implement the requested
feature in a performant way.