### PR TITLE
Make AddProduceIntoExternalKafkaCallback a static singleton.

### DIFF
--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/CommonConstants.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/CommonConstants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons;
 
 public interface CommonConstants {

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/Configuration.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/Configuration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons;
 
 import org.cfg4j.provider.ConfigurationProvider;

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/Metrics.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/Metrics.java
@@ -1,24 +1,39 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons;
 
 import com.expedia.www.haystack.metrics.GraphiteConfig;
 import com.expedia.www.haystack.metrics.MetricPublishing;
 import org.cfg4j.provider.ConfigurationProvider;
 
-public class Metrics {
+class Metrics {
     private final ConfigurationProvider configurationProvider;
     private final MetricPublishing metricPublishing;
 
-    @SuppressWarnings("WeakerAccess") // give unit tests a choice of providing a mock ConfigurationProvider
-    public Metrics(ConfigurationProvider configurationProvider, MetricPublishing metricPublishing) {
+    Metrics(ConfigurationProvider configurationProvider, MetricPublishing metricPublishing) {
         this.configurationProvider = configurationProvider;
         this.metricPublishing = metricPublishing;
     }
 
-    public Metrics() {
+    Metrics() {
         this(new Configuration().createMergeConfigurationProvider(), new MetricPublishing());
     }
 
-    public void startMetricsPolling() {
+    void startMetricsPolling() {
         final GraphiteConfig graphiteConfig = configurationProvider.bind(
                 Configuration.HAYSTACK_GRAPHITE_CONFIG_PREFIX, GraphiteConfig.class);
         metricPublishing.start(graphiteConfig);

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfigurationProvider.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfigurationProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons.kafka;
 
 import com.expedia.www.haystack.pipes.commons.Configuration;

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamBuilder.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons.kafka;
 
 import org.apache.kafka.streams.kstream.KStreamBuilder;

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarter.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons.kafka;
 
 import com.expedia.www.haystack.pipes.commons.Configuration;

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ChangeEnvVarsToLowerCaseConfigurationSourceTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons;
 
 import org.cfg4j.source.context.environment.Environment;

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ConfigurationTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ConfigurationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons;
 
 import org.cfg4j.provider.ConfigurationProvider;

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/MetricsTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/MetricsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons;
 
 import com.expedia.www.haystack.metrics.GraphiteConfig;

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfigurationProviderTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfigurationProviderTest.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons.kafka;
 
-import com.expedia.www.haystack.pipes.commons.kafka.KafkaConfigurationProvider;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,17 +33,17 @@ public class KafkaConfigurationProviderTest {
     public void testBrokers() {
         assertEquals("localhost", kafkaConfigurationProvider.brokers());
     }
-    
+
     @Test
     public void testPort() {
         assertEquals(65534, kafkaConfigurationProvider.port());
     }
-    
+
     @Test
     public void testFromTopic() {
         assertEquals("haystack.kafka.fromtopic", kafkaConfigurationProvider.fromtopic());
     }
-    
+
     @Test
     public void testToTopic() {
         assertEquals("haystack.kafka.totopic", kafkaConfigurationProvider.totopic());

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarterTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons.kafka;
 
 import com.expedia.www.haystack.pipes.commons.SystemExitUncaughtExceptionHandler;

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/serialization/SerializerDeserializerBaseTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/serialization/SerializerDeserializerBaseTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons.serialization;
 
 import com.expedia.www.haystack.metrics.MetricObjects;

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/serialization/SpanSerdeFactoryTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/serialization/SpanSerdeFactoryTest.java
@@ -1,9 +1,22 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons.serialization;
 
 import com.expedia.open.tracing.Span;
-import com.expedia.www.haystack.pipes.commons.serialization.SpanJsonSerializer;
-import com.expedia.www.haystack.pipes.commons.serialization.SpanProtobufDeserializer;
-import com.expedia.www.haystack.pipes.commons.serialization.SpanSerdeFactory;
 import org.apache.kafka.common.serialization.Serde;
 import org.junit.Before;
 import org.junit.Test;

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallback.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallback.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.kafkaProducer;
 
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -10,6 +26,8 @@ public class ProduceIntoExternalKafkaCallback implements Callback {
     static final String DEBUG_MSG = "Successfully posted JSON to Kafka: topic [%s] partition [%d] offset [%d]";
     static final String ERROR_MSG = "Callback exception posting JSON to Kafka; received message [%s]";
     static Logger logger = LoggerFactory.getLogger(ProduceIntoExternalKafkaCallback.class);
+
+    // The static ProduceIntoExternalKafkaAction.CALLBACK means this class must never contain instance variables.
 
     @Override
     public void onCompletion(RecordMetadata metadata, Exception exception) {

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProtobufToKafkaProducer.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProtobufToKafkaProducer.java
@@ -20,7 +20,6 @@ import com.expedia.open.tracing.Span;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaConfigurationProvider;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamBuilder;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter;
-import com.expedia.www.haystack.pipes.commons.Metrics;
 import com.expedia.www.haystack.pipes.commons.serialization.SpanSerdeFactory;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallbackTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallbackTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.kafkaProducer;
 
 import org.apache.kafka.clients.producer.RecordMetadata;

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProtobufToKafkaProducerTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProtobufToKafkaProducerTest.java
@@ -18,7 +18,6 @@ package com.expedia.www.haystack.pipes.kafkaProducer;
 
 import com.expedia.open.tracing.Span;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter;
-import com.expedia.www.haystack.pipes.commons.Metrics;
 import com.expedia.www.haystack.pipes.commons.serialization.SpanSerdeFactory;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.KStream;


### PR DESCRIPTION
Add some copyright notices to Java source files where they were missing.
Fix some warnings (class/constructor visibility, unused imports).