### PR TITLE
Don't send Kafka Producer REQUEST as a rate; send it as a straight count

### DIFF
--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/serialization/SerializerDeserializerBase.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/serialization/SerializerDeserializerBase.java
@@ -51,7 +51,7 @@ class SerializerDeserializerBase {
         static MetricObjects metricObjects = new MetricObjects();
 
         Counter createCounter(String application, String className, String counterName) {
-            return metricObjects.createAndRegisterCounter(
+            return metricObjects.createAndRegisterResettingCounter(
                     SUBSYSTEM, application, className, counterName);
         }
         Timer createTimer(String application, String className, String timerName) {

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/serialization/SerializerDeserializerBaseTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/serialization/SerializerDeserializerBaseTest.java
@@ -96,13 +96,13 @@ public class SerializerDeserializerBaseTest {
 
     @Test
     public void testFactoryCreateCounter() {
-        when(mockMetricObjects.createAndRegisterCounter(anyString(), anyString(), anyString(), anyString()))
+        when(mockMetricObjects.createAndRegisterResettingCounter(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(mockCounter);
 
         final Counter counter = realFactory.createCounter(APPLICATION, CLASS_NAME, COUNTER_NAME);
 
         assertSame(counter, mockCounter);
-        verify(mockMetricObjects).createAndRegisterCounter(SUBSYSTEM, APPLICATION, CLASS_NAME, COUNTER_NAME);
+        verify(mockMetricObjects).createAndRegisterResettingCounter(SUBSYSTEM, APPLICATION, CLASS_NAME, COUNTER_NAME);
     }
 
     @Test

--- a/json-transformer/src/main/resources/base.yaml
+++ b/json-transformer/src/main/resources/base.yaml
@@ -13,3 +13,4 @@ haystack:
      port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
      pollintervalseconds: 60
      queuesize: 10
+     sendasrate: true

--- a/kafka-producer/ReleaseNotes.md
+++ b/kafka-producer/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 2017-12-05 Don't send Kafka Producer REQUEST count as a rate; send it as a straight count instead.
+This requires upgrading haystack-metrics and haystack-logback-metrics-appender, and obtaining a different
+type of Counter (a counter that resets to 0 each time getValue() is called). All count metrics in Kafka Producer
+will no longer be rates.
+
 ## 2017-12-04 Change haystack-metrics-version from 0.2.6 to 0.2.7
 This requires changing the name of the configuration pointing to the Graphite/InfluxDb
 endpoint from `haystack.graphite.address` to `haystack.graphite.host`

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
@@ -52,8 +52,8 @@ public class ProduceIntoExternalKafkaAction implements ForeachAction<String, Spa
 
     @VisibleForTesting static final String ERROR_MSG =
             "Exception posting JSON [%s] to Kafka; received message [%s]";
-    @VisibleForTesting static final Counter REQUEST =
-            METRIC_OBJECTS.createAndRegisterCounter(SUBSYSTEM, APPLICATION, CLASS_NAME, "REQUEST");
+    @VisibleForTesting static Counter REQUEST =
+            METRIC_OBJECTS.createAndRegisterResettingCounter(SUBSYSTEM, APPLICATION, CLASS_NAME, "REQUEST");
     @VisibleForTesting static final ProduceIntoExternalKafkaCallback CALLBACK = new ProduceIntoExternalKafkaCallback();
 
     @VisibleForTesting static Timer KAFKA_PRODUCER_POST = METRIC_OBJECTS.createAndRegisterBasicTimer(

--- a/kafka-producer/src/main/resources/base.yaml
+++ b/kafka-producer/src/main/resources/base.yaml
@@ -13,6 +13,7 @@ haystack:
      port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
      pollintervalseconds: 60
      queuesize: 10
+     sendasrate: false
   externalkafka:
     brokers: "haystack.local" # will point to external Kafka in typical usage
     port: 9092

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <cfg4j-core-version>4.4.1</cfg4j-core-version>
         <commons-lang3-version>3.7</commons-lang3-version>
         <commons-text-version>1.1</commons-text-version>
-        <haystack-metrics-version>0.2.6</haystack-metrics-version>
-        <haystack-logback-metrics-appender-version>0.1.3</haystack-logback-metrics-appender-version>
+        <haystack-metrics-version>0.4.0</haystack-metrics-version>
+        <haystack-logback-metrics-appender-version>0.1.5</haystack-logback-metrics-appender-version>
         <haystack-pipes-commons-version>1.0-SNAPSHOT</haystack-pipes-commons-version>
         <jacoco-maven-plugin-version>0.7.9</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>


### PR DESCRIPTION
instead. This applies to all metrics in Kafka Producer, but JSON
Transformer's ERROR metric continues to be produced as rates for the
time being.