### PR TITLE
Upgrade haystack-logback-custom-appender to 0.1.7, to pick up the change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <commons-lang3-version>3.7</commons-lang3-version>
         <commons-text-version>1.1</commons-text-version>
         <haystack-metrics-version>0.4.0</haystack-metrics-version>
-        <haystack-logback-metrics-appender-version>0.1.6</haystack-logback-metrics-appender-version>
+        <haystack-logback-metrics-appender-version>0.1.7</haystack-logback-metrics-appender-version>
         <haystack-pipes-commons-version>1.0-SNAPSHOT</haystack-pipes-commons-version>
         <jacoco-maven-plugin-version>0.7.9</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>


### PR DESCRIPTION
that emits a heartbeat metric for the error counter, to help create the
dashboard.