### PR TITLE
Use object pool to provide the callback (instead of using a static

### DIFF
--- a/kafka-producer/pom.xml
+++ b/kafka-producer/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-parent</artifactId>
             <type>pom</type>

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
@@ -59,6 +59,8 @@ public class ProduceIntoExternalKafkaAction implements ForeachAction<String, Spa
             "Exception posting JSON [%s] to Kafka; received message [%s]";
     @VisibleForTesting static Counter REQUEST =
             METRIC_OBJECTS.createAndRegisterResettingCounter(SUBSYSTEM, APPLICATION, CLASS_NAME, "REQUEST");
+    @VisibleForTesting static Counter POSTS_IN_FLIGHT =
+            METRIC_OBJECTS.createAndRegisterResettingCounter(SUBSYSTEM, APPLICATION, CLASS_NAME, "POSTS_IN_FLIGHT");
     static ObjectPool<ProduceIntoExternalKafkaCallback> objectPool = new GenericObjectPool<>(new CallbackFactory());
 
     @VisibleForTesting static Timer KAFKA_PRODUCER_POST = METRIC_OBJECTS.createAndRegisterBasicTimer(
@@ -79,6 +81,7 @@ public class ProduceIntoExternalKafkaAction implements ForeachAction<String, Spa
                     factory.createProducerRecord(key, jsonWithFlattenedTags);
 
             final ProduceIntoExternalKafkaCallback callback = objectPool.borrowObject(); // callback must returnObject()
+            POSTS_IN_FLIGHT.increment();
             // TODO Put the Span value into the callback so that it can write it to Kafka for retry
 
             kafkaProducer.send(producerRecord, callback);

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaAction.java
@@ -78,9 +78,8 @@ public class ProduceIntoExternalKafkaAction implements ForeachAction<String, Spa
             final ProducerRecord<String, String> producerRecord =
                     factory.createProducerRecord(key, jsonWithFlattenedTags);
 
-            // The callback is responsible for returning itself to the pool
-            final ProduceIntoExternalKafkaCallback callback = objectPool.borrowObject();
-            // TODO Put producerRecord into the callback so that it can retry
+            final ProduceIntoExternalKafkaCallback callback = objectPool.borrowObject(); // callback must returnObject()
+            // TODO Put the Span value into the callback so that it can write it to Kafka for retry
 
             kafkaProducer.send(producerRecord, callback);
         } catch (Exception exception) {

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallback.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallback.java
@@ -22,6 +22,8 @@ import org.apache.kafka.clients.producer.Callback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaAction.POSTS_IN_FLIGHT;
+
 public class ProduceIntoExternalKafkaCallback implements Callback {
     static final String DEBUG_MSG = "Successfully posted JSON to Kafka: topic [%s] partition [%d] offset [%d]";
     static final String ERROR_MSG_TEMPLATE = "Callback exception posting JSON to Kafka; received message [%s]";
@@ -48,6 +50,7 @@ public class ProduceIntoExternalKafkaCallback implements Callback {
 
     private void returnObjectToPoolButLogExceptionIfReturnFails() {
         try {
+            POSTS_IN_FLIGHT.increment(-1);
             ProduceIntoExternalKafkaAction.objectPool.returnObject(this);
         } catch (Exception exception) {
             logError(exception, POOL_ERROR_MSG_TEMPLATE);

--- a/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallback.java
+++ b/kafka-producer/src/main/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallback.java
@@ -25,23 +25,31 @@ import org.slf4j.LoggerFactory;
 public class ProduceIntoExternalKafkaCallback implements Callback {
     static final String DEBUG_MSG = "Successfully posted JSON to Kafka: topic [%s] partition [%d] offset [%d]";
     static final String ERROR_MSG = "Callback exception posting JSON to Kafka; received message [%s]";
+    static final String POOL_ERROR_MSG = "Exception returning callback to pool; received message [%s]";
     static Logger logger = LoggerFactory.getLogger(ProduceIntoExternalKafkaCallback.class);
-
-    // The static ProduceIntoExternalKafkaAction.CALLBACK means this class must never contain instance variables.
 
     @Override
     public void onCompletion(RecordMetadata metadata, Exception exception) {
-        if(metadata != null) { // means success, per https://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/producer/Callback.html
-            if(logger.isDebugEnabled()) {
-                final String message = String.format(DEBUG_MSG,
-                        metadata.topic(), metadata.partition(), metadata.offset());
-                logger.debug(message);
+        try {
+            if (metadata != null) { // means success, per https://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/producer/Callback.html
+                if (logger.isDebugEnabled()) {
+                    final String message = String.format(DEBUG_MSG,
+                            metadata.topic(), metadata.partition(), metadata.offset());
+                    logger.debug(message);
+                }
             }
-        }
-        if(exception != null) {
-            // Must format below because log4j2 underneath slf4j doesn't handle .error(varargs) properly
-            final String message = String.format(ERROR_MSG, exception.getMessage());
-            logger.error(message, exception);
+            if (exception != null) {
+                // Must format below because log4j2 underneath slf4j doesn't handle .error(varargs) properly
+                final String message = String.format(ERROR_MSG, exception.getMessage());
+                logger.error(message, exception);
+            }
+        } finally {
+            try {
+                ProduceIntoExternalKafkaAction.objectPool.returnObject(this);
+            } catch (Exception returnObjectException) {
+                final String message = String.format(POOL_ERROR_MSG, returnObjectException.getMessage());
+                logger.error(message, returnObjectException);
+            }
         }
     }
 }

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
@@ -85,7 +85,7 @@ public class ProduceIntoExternalKafkaActionTest {
 
     @Before
     public void setUp() {
-        injectMockAndSaveRealObjects();
+        injectMocksAndSaveRealObjects();
         produceIntoExternalKafkaAction = new ProduceIntoExternalKafkaAction();
     }
 
@@ -96,7 +96,7 @@ public class ProduceIntoExternalKafkaActionTest {
                 mockStopwatch);
     }
 
-    private void injectMockAndSaveRealObjects() {
+    private void injectMocksAndSaveRealObjects() {
         saveRealAndInjectMockCounter();
         saveRealAndInjectMockTimer();
         saveRealAndInjectMockLogger();

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaActionTest.java
@@ -32,9 +32,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
 import java.util.Random;
-import java.util.concurrent.ExecutionException;
 
-import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaAction.CALLBACK;
 import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaAction.ERROR_MSG;
 import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaAction.KAFKA_PRODUCER_POST;
 import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaAction.REQUEST;
@@ -140,17 +138,16 @@ public class ProduceIntoExternalKafkaActionTest {
     }
 
     @Test
-    public void testApplySuccessWithTags() throws ExecutionException, InterruptedException {
+    public void testApplySuccessWithTags() {
         testApplySuccess(FULLY_POPULATED_SPAN, JSON_SPAN_STRING_WITH_FLATTENED_TAGS);
     }
 
     @Test
-    public void testApplySuccessWithoutTags() throws ExecutionException, InterruptedException {
+    public void testApplySuccessWithoutTags() {
         testApplySuccess(NO_TAGS_SPAN, JSON_SPAN_STRING_WITH_NO_TAGS);
     }
 
-    private void testApplySuccess(Span span, String jsonSpanString)
-            throws InterruptedException, ExecutionException {
+    private void testApplySuccess(Span span, String jsonSpanString) {
         whensForTestApply();
 
         produceIntoExternalKafkaAction.apply(KEY, span);
@@ -172,7 +169,7 @@ public class ProduceIntoExternalKafkaActionTest {
     }
 
     @Test(expected = OutOfMemoryError.class)
-    public void testApplyOutOfMemoryError() throws ExecutionException, InterruptedException {
+    public void testApplyOutOfMemoryError() {
         whensForTestApply();
         when(mockKafkaProducer.send(any(), any())).thenThrow(new OutOfMemoryError());
 
@@ -194,7 +191,7 @@ public class ProduceIntoExternalKafkaActionTest {
         verify(mockTimer).start();
         verify(mockFactory).createProducerRecord(KEY, jsonSpanString);
         // TODO verify below without any() when the ProduceIntoExternalKafkaCallback object is returned by a factory
-        verify(mockKafkaProducer).send(mockProducerRecord, CALLBACK);
+        verify(mockKafkaProducer).send(eq(mockProducerRecord), any(ProduceIntoExternalKafkaCallback.class));
         verify(mockStopwatch).stop();
     }
 

--- a/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallbackTest.java
+++ b/kafka-producer/src/test/java/com/expedia/www/haystack/pipes/kafkaProducer/ProduceIntoExternalKafkaCallbackTest.java
@@ -31,8 +31,8 @@ import java.util.Random;
 
 import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaAction.objectPool;
 import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaCallback.DEBUG_MSG;
-import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaCallback.ERROR_MSG;
-import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaCallback.POOL_ERROR_MSG;
+import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaCallback.ERROR_MSG_TEMPLATE;
+import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaCallback.POOL_ERROR_MSG_TEMPLATE;
 import static com.expedia.www.haystack.pipes.kafkaProducer.ProduceIntoExternalKafkaCallback.logger;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
@@ -112,13 +112,12 @@ public class ProduceIntoExternalKafkaCallbackTest {
 
     @Test
     public void testOnCompletionBothNullReturnToObjectPoolSuccess() throws Exception {
-        final String exceptionMessage = "Exception Message";
-        final Exception testException = new Exception(exceptionMessage);
+        final Exception testException = new Exception("Exception Message");
         doThrow(testException).when(mockObjectPool).returnObject(any(ProduceIntoExternalKafkaCallback.class));
 
         produceIntoExternalKafkaCallback.onCompletion(null, null);
         verify(mockObjectPool).returnObject(produceIntoExternalKafkaCallback);
-        verify(mockLogger).error(String.format(POOL_ERROR_MSG, exceptionMessage), testException);
+        verify(mockLogger).error(String.format(POOL_ERROR_MSG_TEMPLATE, testException.getMessage()), testException);
     }
 
     @Test
@@ -131,7 +130,7 @@ public class ProduceIntoExternalKafkaCallbackTest {
             produceIntoExternalKafkaCallback.onCompletion(null, testException);
         } catch(Throwable e) {
             assertSame(runtimeException, e);
-            verify(mockLogger).error(String.format(ERROR_MSG, testException.getMessage()), testException);
+            verify(mockLogger).error(String.format(ERROR_MSG_TEMPLATE, testException.getMessage()), testException);
             verify(mockObjectPool).returnObject(produceIntoExternalKafkaCallback);
         }
     }
@@ -164,7 +163,7 @@ public class ProduceIntoExternalKafkaCallbackTest {
         produceIntoExternalKafkaCallback.onCompletion(null, mockException);
 
         verify(mockException).getMessage();
-        verify(mockLogger).error(String.format(ERROR_MSG, MESSAGE), mockException);
+        verify(mockLogger).error(String.format(ERROR_MSG_TEMPLATE, MESSAGE), mockException);
         verify(mockObjectPool).returnObject(produceIntoExternalKafkaCallback);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <!-- Versions -->
         <cfg4j-core-version>4.4.1</cfg4j-core-version>
         <commons-lang3-version>3.7</commons-lang3-version>
+        <commons-pool2-version>2.5.0</commons-pool2-version>
         <commons-text-version>1.1</commons-text-version>
         <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
         <haystack-metrics-version>0.4.0</haystack-metrics-version>
@@ -90,6 +91,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>${commons-pool2-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
callback) so that another change can be made in which the callback
contains a ProducerRecord, permitting retry in the callback.