### PR TITLE
Log Kafka topics at start up, to help determine if pipes is pointing

### DIFF
--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarter.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarter.java
@@ -33,7 +33,7 @@ import java.util.Properties;
 public class KafkaStreamStarter {
     static Factory factory = new Factory(); // will be mocked out in unit tests
     static Logger logger = LoggerFactory.getLogger(KafkaStreamStarter.class);
-    static final String STARTING_MSG = "Attempting to start stream pointing at Kafka [%s]";
+    static final String STARTING_MSG = "Attempting to start stream pointing at Kafka [%s] from topic [%s] to topic [%s]";
     static final String STARTED_MSG = "Now started Stream %s";
     private static final ConfigurationProvider CONFIGURATION_PROVIDER =
             new Configuration().createMergeConfigurationProvider();
@@ -59,7 +59,7 @@ public class KafkaStreamStarter {
         final SystemExitUncaughtExceptionHandler systemExitUncaughtExceptionHandler
                 = factory.createSystemExitUncaughtExceptionHandler(kafkaStreams);
         kafkaStreams.setUncaughtExceptionHandler(systemExitUncaughtExceptionHandler);
-        logger.info(String.format(STARTING_MSG, getKafkaIpAnPort()));
+        logger.info(String.format(STARTING_MSG, getKafkaIpAnPort(), getKafkaFromTopic(), getKafkaToTopic()));
         kafkaStreams.start();
         logger.info(String.format(STARTED_MSG, kStreamBuilder.getClass().getSimpleName()));
     }
@@ -78,6 +78,16 @@ public class KafkaStreamStarter {
     private String getKafkaIpAnPort() {
         final KafkaConfig kafkaConfig = getKafkaConfig();
         return kafkaConfig.brokers() + ":" + kafkaConfig.port();
+    }
+
+    private String getKafkaFromTopic() {
+        final KafkaConfig kafkaConfig = getKafkaConfig();
+        return kafkaConfig.fromtopic();
+    }
+
+    private String getKafkaToTopic() {
+        final KafkaConfig kafkaConfig = getKafkaConfig();
+        return kafkaConfig.totopic();
     }
 
     private int getReplicationFactor() {

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarterTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarterTest.java
@@ -50,6 +50,8 @@ public class KafkaStreamStarterTest {
     private final static Random RANDOM = new Random();
     private final static String CLIENT_ID = RANDOM.nextLong() + "CLIENT_ID";
     private static final String KAFKA_IP_AND_PORT = "localhost:" + 65534;
+    private static final String KAFKA_FROM_TOPIC = "haystack.kafka.fromtopic";
+    private static final String KAFKA_TO_TOPIC = "haystack.kafka.totopic";
 
     @Mock
     private Factory mockFactory;
@@ -109,7 +111,7 @@ public class KafkaStreamStarterTest {
         verify(mockFactory).createSystemExitUncaughtExceptionHandler(mockKafkaStreams);
         verify(mockKafkaStreams).setUncaughtExceptionHandler(mockSystemExitUncaughtExceptionHandler);
         verify(mockKafkaStreams).start();
-        verify(mockLogger).info(String.format(STARTING_MSG, KAFKA_IP_AND_PORT));
+        verify(mockLogger).info(String.format(STARTING_MSG, KAFKA_IP_AND_PORT, KAFKA_FROM_TOPIC, KAFKA_TO_TOPIC));
         verify(mockLogger).info(String.format(STARTED_MSG, mockKStreamBuilder.getClass().getSimpleName()));
 
     }


### PR DESCRIPTION
at the correct Kafka topic.