### PR TITLE
Finish implementation and unit tests for http-poster.

### DIFF
--- a/http-poster/pom.xml
+++ b/http-poster/pom.xml
@@ -89,6 +89,10 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
         </dependency>
@@ -117,6 +121,6 @@
                 </configuration>
             </plugin>
         </plugins>
-   </build>
+    </build>
 
 </project>

--- a/http-poster/src/main/java/com/expedia/www/haystack/pipes/httpPoster/HttpPostAction.java
+++ b/http-poster/src/main/java/com/expedia/www/haystack/pipes/httpPoster/HttpPostAction.java
@@ -1,33 +1,120 @@
 package com.expedia.www.haystack.pipes.httpPoster;
 
 import com.expedia.open.tracing.Span;
-import com.expedia.www.haystack.metrics.MetricObjects;
-import com.google.protobuf.util.JsonFormat;
+import com.expedia.www.haystack.pipes.commons.kafka.TagFlattener;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat.Printer;
 import com.netflix.servo.monitor.Counter;
+import com.netflix.servo.monitor.Stopwatch;
+import com.netflix.servo.monitor.Timer;
+import com.netflix.servo.util.VisibleForTesting;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.streams.kstream.ForeachAction;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
 @Component
 class HttpPostAction implements ForeachAction<String, Span> {
+    @VisibleForTesting
+    static final String POSTING_ERROR_MSG = "Exception posting to HTTP; received message [%s]";
+    @VisibleForTesting
+    static final String PROTOBUF_ERROR_MSG = "Exception printing Span [%s]; received message [%s]";
+
+    private final TagFlattener tagFlattener = new TagFlattener();
+    private final Printer printer;
     private final ContentCollector contentCollector;
-    private final MetricObjects metricObjects;
-    private final Printer printer = JsonFormat.printer().omittingInsignificantWhitespace();
     private final Counter requestCounter;
+    private final Timer httpPostTimer;
+    private final Logger httpPostActionLogger;
+    private final HttpPostConfigurationProvider httpPostConfigurationProvider;
+    private final Factory factory;
 
     @Autowired
-    HttpPostAction(ContentCollector contentCollector,
-                   MetricObjects metricObjects,
-                   Counter requestCounter) {
+    HttpPostAction(Printer printer,
+                   ContentCollector contentCollector,
+                   Counter requestCounter,
+                   Timer httpPostTimer,
+                   Logger httpPostActionLogger,
+                   HttpPostConfigurationProvider httpPostConfigurationProvider,
+                   Factory httpPostActionFactory) {
+        this.printer = printer;
         this.contentCollector = contentCollector;
-        this.metricObjects = metricObjects;
         this.requestCounter = requestCounter;
+        this.httpPostTimer = httpPostTimer;
+        this.httpPostActionLogger = httpPostActionLogger;
+        this.httpPostConfigurationProvider = httpPostConfigurationProvider;
+        this.factory = httpPostActionFactory;
     }
 
     @Override
-    public void apply(String key, Span value) {
+    public void apply(String key, Span span) {
         requestCounter.increment();
-        // TODO Post to HTTP endpoint
+        final String batch = getBatch(span);
+        if (!StringUtils.isEmpty(batch)) {
+            final Stopwatch stopwatch = httpPostTimer.start();
+            try(final OutputStream outputStream = getOutputStream(batch)) {
+                outputStream.write(batch.getBytes());
+            } catch(Exception exception){
+                // Must format below because log4j2 underneath slf4j doesn't handle .error(varargs) properly
+                final String message = String.format(POSTING_ERROR_MSG, exception.getMessage());
+                httpPostActionLogger.error(message, exception);
+            } finally {
+                stopwatch.stop();
+            }
+        }
+    }
+
+    @VisibleForTesting
+    String getBatch(Span span) {
+        String jsonWithFlattenedTags;
+        final String jsonWithOpenTracingTags;
+        try {
+            jsonWithOpenTracingTags = printer.print(span);
+            jsonWithFlattenedTags = tagFlattener.flattenTags(jsonWithOpenTracingTags);
+            return contentCollector.addAndReturnBatch(jsonWithFlattenedTags);
+        } catch (InvalidProtocolBufferException exception) {
+            // Must format below because log4j2 underneath slf4j doesn't handle .error(varargs) properly
+            final String message = String.format(PROTOBUF_ERROR_MSG, span.toString(), exception.getMessage());
+            httpPostActionLogger.error(message, exception);
+            return "";
+        }
+    }
+
+    private HttpURLConnection getUrlConnection() throws IOException {
+        final String url = httpPostConfigurationProvider.url();
+        final URL factoryURL = factory.createURL(url);
+        return factory.createConnection(factoryURL);
+    }
+
+    private OutputStream getOutputStream(String batch) throws IOException {
+        final HttpURLConnection httpURLConnection = getUrlConnection();
+        httpURLConnection.setRequestMethod("POST");
+        setHeaders(batch, httpURLConnection);
+        return httpURLConnection.getOutputStream();
+    }
+
+    private void setHeaders(String batch, HttpURLConnection httpURLConnection) {
+        httpURLConnection.setRequestProperty("Content-Length", Integer.toString(batch.length()));
+        for (Map.Entry<String, String> header : httpPostConfigurationProvider.headers().entrySet()) {
+            httpURLConnection.setRequestProperty(header.getKey(), header.getValue());
+        }
+    }
+
+    static class Factory {
+        URL createURL(String url) throws MalformedURLException {
+            return new URL(url);
+        }
+
+        HttpURLConnection createConnection(URL url) throws IOException {
+            return (HttpURLConnection) url.openConnection();
+        }
     }
 }

--- a/http-poster/src/main/resources/base.yaml
+++ b/http-poster/src/main/resources/base.yaml
@@ -10,8 +10,8 @@ haystack:
   httppost:
     maxbytes: 1572864 # 1.5 MB
     endpoint: "https://collector.test.expedia.com"
-    url: /haystack-spans.json?stream=true&persist=false&multilines=true
-    separator: "\n"
-    bodyprefix: ""
-    bodysuffix: ""
-    headers: Content-Type=raw
+    url: "/haystack-spans.json?stream=true&persist=false&multilines=true"
+    separator: "\n" # These values for separator, bodyprefix, and bodysuffix are
+    bodyprefix: ""  # appropriate for creating a POST body that consists of newline
+    bodysuffix: ""  # newline delimited Span objects with each object in valid JSON
+    headers: "Content-Type=raw"

--- a/http-poster/src/main/resources/log4j2.yaml
+++ b/http-poster/src/main/resources/log4j2.yaml
@@ -1,0 +1,28 @@
+Configuration:
+  appenders:
+    Console:
+      name: Console
+      PatternLayout:
+        Pattern: "%%d{HH:mm:ss.SSS} %level [%thread] %X{requestid} %logger{10} %msg%n"
+      target: SYSTEM_OUT
+    EmitToGraphiteLog4jAppender:
+      name: EmitToGraphiteLog4jAppender
+      subsystem: pipes
+      host: "haystack.local" # set in /etc/hosts per instructions in haystack-deployment package
+      port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
+      pollintervalseconds: 60
+      queuesize: 10
+      sendasrate: false
+  Loggers:
+    Logger:
+      name: com.expedia.www.haystack.pipes.httpPoster.HttpPostIsActiveController
+      level: info
+      additivity: false
+      AppenderRef:
+        - ref: Console
+        - ref: EmitToGraphiteLog4jAppender
+    Root:
+      level: error
+      AppenderRef:
+        - ref: Console
+        - ref: EmitToGraphiteLog4jAppender

--- a/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/HttpPostActionTest.java
+++ b/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/HttpPostActionTest.java
@@ -1,46 +1,212 @@
 package com.expedia.www.haystack.pipes.httpPoster;
 
-import com.expedia.www.haystack.metrics.MetricObjects;
+import com.expedia.open.tracing.Span;
+import com.expedia.www.haystack.pipes.httpPoster.HttpPostAction.Factory;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.JsonFormat.Printer;
 import com.netflix.servo.monitor.Counter;
+import com.netflix.servo.monitor.Stopwatch;
+import com.netflix.servo.monitor.Timer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockserver.integration.ClientAndServer;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.FULLY_POPULATED_SPAN;
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.JSON_SPAN_STRING_WITH_FLATTENED_TAGS;
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.NO_TAGS_SPAN;
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static com.expedia.www.haystack.pipes.httpPoster.HttpPostAction.POSTING_ERROR_MSG;
+import static com.expedia.www.haystack.pipes.httpPoster.HttpPostAction.PROTOBUF_ERROR_MSG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpPostActionTest {
     private final static String KEY = RANDOM.nextLong() + "KEY";
+    private static final String HTTP_LOCALHOST = "http://localhost:1080";
+    private static final String EXCEPTION_MESSAGE = "Test Exception";
+    private static final IOException IO_EXCEPTION = new IOException(EXCEPTION_MESSAGE);
+    private static final String IO_EXCEPTION_MESSAGE = String.format(POSTING_ERROR_MSG, EXCEPTION_MESSAGE);
+    static final Map<String, String> HEADERS = new HashMap<>(2);
+    private static URL URL_;
 
+    static {
+        try {
+            URL_ = new URL(HTTP_LOCALHOST);
+            HEADERS.put("Content-Type", "raw");
+            HEADERS.put("Content-Encoding", "gzip");
+        } catch (MalformedURLException e) {
+            URL_ = null;
+        }
+    }
+
+    @Mock
+    private Printer mockPrinter;
     @Mock
     private ContentCollector mockContentCollector;
     @Mock
-    private MetricObjects mockMetricObjects;
-    @Mock
     private Counter mockRequestCounter;
+    @Mock
+    private Timer mockHttpPostTimer;
+    @Mock
+    private Logger mockLogger;
+    @Mock
+    private HttpPostConfigurationProvider mockHttpPostConfigurationProvider;
+    @Mock
+    private Factory mockFactory;
+    @Mock
+    private Stopwatch mockStopwatch;
+    @Mock
+    private HttpURLConnection mockHttpURLConnection;
+    @Mock
+    private OutputStream mockOutputStream;
 
     private HttpPostAction httpPostExternalAction;
+    private Factory factory;
+    private ClientAndServer mockServer;
 
     @Before
     public void setUp() {
-        httpPostExternalAction = new HttpPostAction(mockContentCollector, mockMetricObjects, mockRequestCounter);
+        final Printer realPrinter = JsonFormat.printer().omittingInsignificantWhitespace();
+        httpPostExternalAction = new HttpPostAction(realPrinter, mockContentCollector, mockRequestCounter,
+                mockHttpPostTimer, mockLogger, mockHttpPostConfigurationProvider, mockFactory);
+        factory = new Factory();
+        mockServer = ClientAndServer.startClientAndServer(1080);
     }
 
     @After
     public void tearDown() {
-        verifyNoMoreInteractions(mockContentCollector, mockMetricObjects, mockRequestCounter);
+        mockServer.stop();
+        verifyNoMoreInteractions(mockPrinter, mockContentCollector, mockRequestCounter,
+                mockHttpPostTimer, mockLogger, mockHttpPostConfigurationProvider, mockFactory,
+                mockStopwatch, mockHttpURLConnection, mockOutputStream);
     }
 
     @Test
-    public void testApply() {
+    public void testApplyEmptyBatch() {
+        when(mockContentCollector.addAndReturnBatch(anyString())).thenReturn("");
+
         httpPostExternalAction.apply(KEY, FULLY_POPULATED_SPAN);
 
         verify(mockRequestCounter).increment();
+        verify(mockContentCollector).addAndReturnBatch(JSON_SPAN_STRING_WITH_FLATTENED_TAGS);
+    }
+
+    @Test
+    public void testApplyFullBatchHappyCase() throws IOException {
+        when(mockHttpURLConnection.getOutputStream()).thenReturn(mockOutputStream);
+
+        testApply();
+
+        verify(mockOutputStream).write(JSON_SPAN_STRING_WITH_FLATTENED_TAGS.getBytes());
+        verify(mockOutputStream).close();
+    }
+
+    @Test
+    public void testApplyIOExceptionFromGetOutputStream() throws IOException {
+        when(mockHttpURLConnection.getOutputStream()).thenThrow(IO_EXCEPTION);
+
+        testApply();
+
+        verify(mockLogger).error(IO_EXCEPTION_MESSAGE, IO_EXCEPTION);
+    }
+
+    @Test
+    public void testApplyIOExceptionFromWrite() throws IOException {
+        when(mockHttpURLConnection.getOutputStream()).thenReturn(mockOutputStream);
+        doThrow(IO_EXCEPTION).when(mockOutputStream).write(any(byte[].class));
+
+        testApply();
+
+        verify(mockOutputStream).write(JSON_SPAN_STRING_WITH_FLATTENED_TAGS.getBytes());
+        verify(mockOutputStream).close();
+        verify(mockLogger).error(IO_EXCEPTION_MESSAGE, IO_EXCEPTION);
+    }
+
+    @Test
+    public void testApplyIOExceptionFromClose() throws IOException {
+        doThrow(IO_EXCEPTION).when(mockOutputStream).close();
+
+        when(mockHttpURLConnection.getOutputStream()).thenReturn(mockOutputStream);
+
+        testApply();
+
+        verify(mockOutputStream).write(JSON_SPAN_STRING_WITH_FLATTENED_TAGS.getBytes());
+        verify(mockOutputStream).close();
+        verify(mockLogger).error(IO_EXCEPTION_MESSAGE, IO_EXCEPTION);
+    }
+
+    private void testApply() throws IOException {
+        when(mockContentCollector.addAndReturnBatch(anyString()))
+                .thenReturn("").thenReturn(JSON_SPAN_STRING_WITH_FLATTENED_TAGS);
+        when(mockHttpPostConfigurationProvider.url()).thenReturn(HTTP_LOCALHOST);
+        when(mockHttpPostTimer.start()).thenReturn(mockStopwatch);
+        when(mockFactory.createURL(anyString())).thenReturn(URL_);
+        when(mockFactory.createConnection(any(URL.class))).thenReturn(mockHttpURLConnection);
+        when(mockHttpPostConfigurationProvider.headers()).thenReturn(HEADERS);
+
+        httpPostExternalAction.apply(KEY, FULLY_POPULATED_SPAN);
+        httpPostExternalAction.apply(KEY, FULLY_POPULATED_SPAN);
+
+        verify(mockRequestCounter, times(2)).increment();
+        verify(mockContentCollector, times(2)).addAndReturnBatch(
+                JSON_SPAN_STRING_WITH_FLATTENED_TAGS);
+        verify(mockHttpPostTimer).start();
+        verify(mockHttpPostConfigurationProvider).url();
+        verify(mockFactory).createURL(HTTP_LOCALHOST);
+        verify(mockFactory).createConnection(URL_);
+        verify(mockHttpURLConnection).setRequestMethod("POST");
+        verify(mockHttpURLConnection).setRequestProperty(
+                "Content-Length", Integer.toString(JSON_SPAN_STRING_WITH_FLATTENED_TAGS.length()));
+        verify(mockHttpPostConfigurationProvider).headers();
+        for (Map.Entry<String, String> header : HEADERS.entrySet()) {
+            verify(mockHttpURLConnection).setRequestProperty(header.getKey(), header.getValue());
+        }
+        verify(mockHttpURLConnection).getOutputStream();
+        verify(mockStopwatch).stop();
+    }
+
+    @Test
+    public void testGetBatchInvalidProtocolBufferException() throws InvalidProtocolBufferException {
+        httpPostExternalAction = new HttpPostAction(mockPrinter, mockContentCollector, mockRequestCounter, mockHttpPostTimer,
+                mockLogger, mockHttpPostConfigurationProvider, mockFactory);
+        final InvalidProtocolBufferException exception = new InvalidProtocolBufferException(EXCEPTION_MESSAGE);
+        when(mockPrinter.print(any(Span.class))).thenThrow(exception);
+
+        final String batch = httpPostExternalAction.getBatch(NO_TAGS_SPAN);
+
+        assertEquals("", batch);
+        verify(mockPrinter).print(NO_TAGS_SPAN);
+        final String message = String.format(PROTOBUF_ERROR_MSG, NO_TAGS_SPAN.toString(), EXCEPTION_MESSAGE);
+        verify(mockLogger).error(message, exception);
+    }
+
+    @Test
+    public void testFactoryMethods() throws IOException {
+        final URL url = factory.createURL(HTTP_LOCALHOST);
+        assertNotNull(url);
+        final HttpURLConnection httpURLConnection = factory.createConnection(url);
+        assertNotNull(httpURLConnection);
     }
 }

--- a/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/HttpPostConfigurationProviderTest.java
+++ b/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/HttpPostConfigurationProviderTest.java
@@ -3,9 +3,9 @@ package com.expedia.www.haystack.pipes.httpPoster;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 
+import static com.expedia.www.haystack.pipes.httpPoster.HttpPostActionTest.HEADERS;
 import static org.junit.Assert.assertEquals;
 
 public class HttpPostConfigurationProviderTest {
@@ -63,9 +63,6 @@ public class HttpPostConfigurationProviderTest {
     public void testHeaders() {
         final Map<String, String> headers = httpPostConfigurationProvider.headers();
 
-        final Map<String, String> expected = new HashMap<>();
-        expected.put("Content-Type", "raw");
-        expected.put("Content-Encoding", "gzip");
-        assertEquals(expected, headers);
+        assertEquals(HEADERS, headers);
     }
 }

--- a/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/SpringConfigTest.java
+++ b/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/SpringConfigTest.java
@@ -2,6 +2,7 @@ package com.expedia.www.haystack.pipes.httpPoster;
 
 import com.expedia.www.haystack.metrics.MetricObjects;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter;
+import com.netflix.servo.monitor.Timer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,8 +11,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
+import java.util.concurrent.TimeUnit;
+
 import static com.expedia.www.haystack.pipes.commons.CommonConstants.SUBSYSTEM;
 import static com.expedia.www.haystack.pipes.httpPoster.Constants.APPLICATION;
+import static com.expedia.www.haystack.pipes.httpPoster.SpringConfig.HTTP_POST_ACTION_CLASS_SIMPLE_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.verify;
@@ -39,7 +43,15 @@ public class SpringConfigTest {
         springConfig.requestCounter();
 
         verify(mockMetricObjects).createAndRegisterResettingCounter(SUBSYSTEM, APPLICATION,
-                HttpPostAction.class.getName(), "REQUEST");
+                HttpPostAction.class.getSimpleName(), "REQUEST");
+    }
+
+    @Test
+    public void testHttpPostTimer() {
+        final Timer timer = springConfig.httpPostTimer();
+
+        verify(mockMetricObjects).createAndRegisterBasicTimer(SUBSYSTEM, APPLICATION,
+                HTTP_POST_ACTION_CLASS_SIMPLE_NAME, "HTTP_POST", TimeUnit.MICROSECONDS);
     }
 
     @Test
@@ -48,6 +60,13 @@ public class SpringConfigTest {
 
         assertSame(ProtobufToHttpPoster.class, kafkaStreamStarter.containingClass);
         assertSame(APPLICATION, kafkaStreamStarter.clientId);
+    }
+
+    @Test
+    public void testHttpPostActionLogger() {
+        final Logger logger = springConfig.httpPostActionLogger();
+
+        assertEquals(HttpPostAction.class.getName(), logger.getName());
     }
 
     @Test

--- a/http-poster/src/test/resources/base.yaml
+++ b/http-poster/src/test/resources/base.yaml
@@ -10,8 +10,8 @@ haystack:
   httppost:
     maxbytes: 1572864 # 1.5 MB
     endpoint: "https://collector.test.expedia.com"
-    url: /haystack-spans.json?stream=true&persist=false&multilines=true
+    url: "/haystack-spans.json?stream=true&persist=false&multilines=true"
     separator: ","  # These values for separator, bodyprefix, and bodysuffix
     bodyprefix: "[" # are appropriate for creating an array of JSON objects
     bodysuffix: "]" # in the body of the POST in valid JSON syntax
-    headers: Content-Type=raw,Content-Encoding=gzip
+    headers: "Content-Type=raw,Content-Encoding=gzip"

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <haystack-logback-metrics-appender-version>0.1.10</haystack-logback-metrics-appender-version>
         <haystack-log4j-metrics-appender-version>0.1.6</haystack-log4j-metrics-appender-version>
         <haystack-pipes-commons-version>1.0-SNAPSHOT</haystack-pipes-commons-version>
-        <jacoco-maven-plugin-version>0.7.9</jacoco-maven-plugin-version>
+        <jacoco-maven-plugin-version>0.8.0</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>
         <jackson-version>2.9.1</jackson-version>
         <java-version>1.8</java-version>
@@ -34,6 +34,7 @@
         <maven-compiler-plugin-version>3.6.1</maven-compiler-plugin-version>
         <maven-jar-plugin-version>3.0.2</maven-jar-plugin-version>
         <mockito-version>1.9.5</mockito-version>
+        <mockserver-netty-version>5.3.0</mockserver-netty-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf-java-util-version>3.3.1</protobuf-java-util-version>
         <protoc-jar-maven-version>3.3.0.1</protoc-jar-maven-version>
@@ -223,6 +224,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit-version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mock-server</groupId>
+                <artifactId>mockserver-netty</artifactId>
+                <version>${mockserver-netty-version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Also upgraded JaCoCo to 8.0 (this appears to have fixed some coverage
calculation problems with catch and finally blocks). Brought in
mockserver-netty to start a local HTTP server in some unit tests, which
made writing tests and achieving 100% coverage easier. Note that
mockserver-netty starts up and shuts down very quickly, so the impact
on build times is not severe.