### PR TITLE
Springify json-transformer. Upgrade to new versions of haystack-metrics,

### DIFF
--- a/json-transformer/pom.xml
+++ b/json-transformer/pom.xml
@@ -81,6 +81,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/JsonTransformerIsActiveController.java
+++ b/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/JsonTransformerIsActiveController.java
@@ -16,28 +16,53 @@
  */
 package com.expedia.www.haystack.pipes.jsonTransformer;
 
+import com.netflix.servo.util.VisibleForTesting;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A very simple Spring Boot application that is intended to support only a single REST endpoint (index.html)
  * to indicate that the JVM is running.
  */
 @SpringBootApplication
+@Component
 public class JsonTransformerIsActiveController extends SpringBootServletInitializer {
-    static Factory factory = new Factory();
+    // Singleton, initialized on first constructor call, so that future instances created by Spring during unit tests
+    // will not overwrite the initial INSTANCE (with mocks) created by the unit tests.
+    @VisibleForTesting
+    static final AtomicReference<JsonTransformerIsActiveController> INSTANCE = new AtomicReference<>();
+    @VisibleForTesting
+    static final String STARTUP_MSG = "Starting JsonTransformerIsActiveController";
+
+    private final ProtobufToJsonTransformer protobufToJsonTransformer;
+    private final Factory factory;
+    private final Logger logger;
+
+    @Autowired
+    public JsonTransformerIsActiveController(ProtobufToJsonTransformer protobufToJsonTransformer,
+                                             Factory jsonTransformerIsActiveControllerFactory,
+                                             Logger jsonTransformerIsActiveControllerLogger) {
+        this.protobufToJsonTransformer = protobufToJsonTransformer;
+        this.factory = jsonTransformerIsActiveControllerFactory;
+        this.logger = jsonTransformerIsActiveControllerLogger;
+        INSTANCE.compareAndSet(null, this);
+    }
 
     public static void main(String[] args) {
-        factory.createProtobufToJsonTransformer().main();
-        factory.createSpringApplication().run(args);
+        new AnnotationConfigApplicationContext(SpringConfig.class);
+        INSTANCE.get().logger.info(STARTUP_MSG);
+        INSTANCE.get().protobufToJsonTransformer.main();
+        INSTANCE.get().factory.createSpringApplication().run(args);
     }
 
     static class Factory {
-        ProtobufToJsonTransformer createProtobufToJsonTransformer() {
-            return new ProtobufToJsonTransformer();
-        }
-
         SpringApplication createSpringApplication() {
             return new SpringApplication(JsonTransformerIsActiveController.class);
         }

--- a/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformer.java
+++ b/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformer.java
@@ -25,20 +25,20 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import static com.expedia.www.haystack.pipes.jsonTransformer.Constants.APPLICATION;
 
+@Component
 public class ProtobufToJsonTransformer implements KafkaStreamBuilder {
-    private static final KafkaConfigurationProvider KAFKA_CONFIGURATION_PROVIDER = new KafkaConfigurationProvider();
-
-    final KafkaStreamStarter kafkaStreamStarter;
+    private final KafkaStreamStarter kafkaStreamStarter;
     private final SpanSerdeFactory spanSerdeFactory;
+    private final KafkaConfigurationProvider kafkaConfigurationProvider = new KafkaConfigurationProvider();
 
-    ProtobufToJsonTransformer() {
-        this(new KafkaStreamStarter(ProtobufToJsonTransformer.class, APPLICATION), new SpanSerdeFactory());
-    }
-
-    ProtobufToJsonTransformer(KafkaStreamStarter kafkaStreamStarter, SpanSerdeFactory spanSerdeFactory) {
+    @Autowired
+    ProtobufToJsonTransformer(KafkaStreamStarter kafkaStreamStarter,
+                              SpanSerdeFactory spanSerdeFactory) {
         this.kafkaStreamStarter = kafkaStreamStarter;
         this.spanSerdeFactory = spanSerdeFactory;
     }
@@ -56,8 +56,8 @@ public class ProtobufToJsonTransformer implements KafkaStreamBuilder {
         final Serde<Span> spanSerde = spanSerdeFactory.createSpanSerde(APPLICATION);
         final Serde<String> stringSerde = Serdes.String();
         final KStream<String, Span> stream = kStreamBuilder.stream(
-                stringSerde, spanSerde, KAFKA_CONFIGURATION_PROVIDER.fromtopic());
-        stream.mapValues(span->span).to(stringSerde, spanSerde, KAFKA_CONFIGURATION_PROVIDER.totopic());
+                stringSerde, spanSerde, kafkaConfigurationProvider.fromtopic());
+        stream.mapValues(span->span).to(stringSerde, spanSerde, kafkaConfigurationProvider.totopic());
     }
 
 }

--- a/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/SpringConfig.java
+++ b/json-transformer/src/main/java/com/expedia/www/haystack/pipes/jsonTransformer/SpringConfig.java
@@ -1,0 +1,46 @@
+package com.expedia.www.haystack.pipes.jsonTransformer;
+
+import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter;
+import com.expedia.www.haystack.pipes.commons.serialization.SpanSerdeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static com.expedia.www.haystack.pipes.jsonTransformer.Constants.APPLICATION;
+
+@Configuration
+@ComponentScan(basePackageClasses = SpringConfig.class)
+public class SpringConfig {
+    // Beans with unit tests ///////////////////////////////////////////////////////////////////////////////////////////
+    @Bean
+    Logger jsonTransformerIsActiveControllerLogger() {
+        return LoggerFactory.getLogger(JsonTransformerIsActiveController.class);
+    }
+
+    @Bean
+    KafkaStreamStarter kafkaStreamStarter() {
+        return new KafkaStreamStarter(ProtobufToJsonTransformer.class, APPLICATION);
+    }
+
+    // Beans without unit tests ////////////////////////////////////////////////////////////////////////////////////////
+    @Bean
+    SpanSerdeFactory spanSerdeFactory() {
+        return new SpanSerdeFactory();
+    }
+
+    @Bean
+    JsonTransformerIsActiveController.Factory jsonTransformerIsActiveControllerFactory() {
+        return new JsonTransformerIsActiveController.Factory();
+    }
+
+    @Bean
+    @Autowired
+    ProtobufToJsonTransformer protobufToJsonTransformer(KafkaStreamStarter kafkaStreamStarter,
+                                                        SpanSerdeFactory spanSerdeFactory) {
+        return new ProtobufToJsonTransformer(kafkaStreamStarter, spanSerdeFactory);
+    }
+
+}

--- a/json-transformer/src/main/resources/application.properties
+++ b/json-transformer/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+# See https://stackoverflow.com/questions/41317645/springapplicationadminregistrar-invocation-of-init-method-failed-nested-excep
+#      "...the boot is running on the same package that the other beans get scanned.
+#       ...the context application is loaded twice, although there is only one component scan"
+# The lines below are the workaround, which permits the Spring Boot application and the beans to be in the same package.
+# ADMIN (SpringApplicationAdminJmxAutoConfiguration)
+spring.application.admin.enabled=true
+spring.application.admin.jmx-name=org.springframework.boot:type=Admin,name=SpringApplication # JMX name of the application admin MBean.

--- a/json-transformer/src/main/resources/logback.xml
+++ b/json-transformer/src/main/resources/logback.xml
@@ -13,9 +13,15 @@
     </appender>
     <logger name="com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter" additivity="false" level="INFO">
         <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
+        <appender-ref ref="EmitToGraphiteLogbackAppender" />
     </logger>
     <logger name="com.netflix.servo.publish.graphite.GraphiteMetricObserver" additivity="false" level="INFO">
         <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
+        <appender-ref ref="EmitToGraphiteLogbackAppender" />
+    </logger>
+    <logger name="com.expedia.www.haystack.pipes.jsonTransformer.JsonTransformerIsActiveController" additivity="false" level="INFO">
+        <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
+        <appender-ref ref="EmitToGraphiteLogbackAppender" />
     </logger>
     <root level="WARN">
         <appender-ref ref="STDOUT" />

--- a/json-transformer/src/test/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformerTest.java
+++ b/json-transformer/src/test/java/com/expedia/www/haystack/pipes/jsonTransformer/ProtobufToJsonTransformerTest.java
@@ -33,8 +33,6 @@ import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static com.expedia.www.haystack.pipes.jsonTransformer.Constants.APPLICATION;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -65,14 +63,6 @@ public class ProtobufToJsonTransformerTest {
     public void tearDown() {
         verifyNoMoreInteractions(mockKafkaStreamStarter, mockKStreamBuilder, mockKStreamStringSpan,
                 mockKStreamStringSpanJsonSerializer);
-    }
-
-    @Test
-    public void testDefaultConstructor() {
-        protobufToJsonTransformer = new ProtobufToJsonTransformer();
-
-        assertEquals(APPLICATION, protobufToJsonTransformer.kafkaStreamStarter.clientId);
-        assertEquals(ProtobufToJsonTransformer.class, protobufToJsonTransformer.kafkaStreamStarter.containingClass);
     }
 
     @Test

--- a/json-transformer/src/test/java/com/expedia/www/haystack/pipes/jsonTransformer/SpringConfigTest.java
+++ b/json-transformer/src/test/java/com/expedia/www/haystack/pipes/jsonTransformer/SpringConfigTest.java
@@ -1,0 +1,37 @@
+package com.expedia.www.haystack.pipes.jsonTransformer;
+
+import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import static com.expedia.www.haystack.pipes.jsonTransformer.Constants.APPLICATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class SpringConfigTest {
+    private SpringConfig springConfig;
+
+    @Before
+    public void setUp() {
+        springConfig = new SpringConfig();
+    }
+
+    @Test
+    public void testJsonTransformerIsActiveControllerLogger() {
+        final Logger logger = springConfig.jsonTransformerIsActiveControllerLogger();
+
+        assertEquals(JsonTransformerIsActiveController.class.getName(), logger.getName());
+    }
+
+    @Test
+    public void testKafkaStreamStarter() {
+        final KafkaStreamStarter kafkaStreamStarter = springConfig.kafkaStreamStarter();
+
+        assertSame(ProtobufToJsonTransformer.class, kafkaStreamStarter.containingClass);
+        assertSame(APPLICATION, kafkaStreamStarter.clientId);
+    }
+
+    // All of the other beans in SpringConfig use default constructors, or use arguments provided by other Spring beans
+    // in SpringConfig, so tests on the methods that create those beans have little value.
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
         <commons-pool2-version>2.5.0</commons-pool2-version>
         <commons-text-version>1.1</commons-text-version>
         <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
-        <haystack-metrics-version>0.5.0</haystack-metrics-version>
-        <haystack-logback-metrics-appender-version>0.1.10</haystack-logback-metrics-appender-version>
-        <haystack-log4j-metrics-appender-version>0.1.6</haystack-log4j-metrics-appender-version>
+        <haystack-metrics-version>0.6.0</haystack-metrics-version>
+        <haystack-logback-metrics-appender-version>0.1.11</haystack-logback-metrics-appender-version>
+        <haystack-log4j-metrics-appender-version>0.1.7</haystack-log4j-metrics-appender-version>
         <haystack-pipes-commons-version>1.0-SNAPSHOT</haystack-pipes-commons-version>
         <jacoco-maven-plugin-version>0.8.0</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>


### PR DESCRIPTION
haystack-logback-metrics-appender, and haystack-log4j-metrics-appender;
doing so allows Logback and Spring to function properly when Logback
decides to "reset" the logging system before it's fully running. (This
is the first time that we've used Logback and Spring together; the
Pipes modules that were already Springified use log4j 2.)