### PR TITLE
Add graphite (really InfluxDb) configurations to base.yaml, which serves

### DIFF
--- a/http-poster/src/main/resources/base.yaml
+++ b/http-poster/src/main/resources/base.yaml
@@ -7,10 +7,17 @@ haystack:
   pipe:
     streams:
       replicationfactor: 1
+  graphite:
+     prefix: "haystack"
+     host: "haystack.local" # set in /etc/hosts per instructions in haystack-deployment package
+     port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
+     pollintervalseconds: 60
+     queuesize: 10
+     sendasrate: false
   httppost:
     maxbytes: 1572864 # 1.5 MB
     url: "https://collector.test.expedia.com/haystack-spans.json?stream=true&persist=false&multilines=true"
-    separator: "\n" # These values for separator, bodyprefix, and bodysuffix are
-    bodyprefix: ""  # appropriate for creating a POST body that consists of newline
-    bodysuffix: ""  # newline delimited Span objects with each object in valid JSON
+    separator: "\n" # These values for separator, bodyprefix, and bodysuffix
+    bodyprefix: ""  # are appropriate for creating a POST body that consists of
+    bodysuffix: ""  # newline-delimited Span objects with each object in valid JSON
     headers: "Content-Type=raw"


### PR DESCRIPTION
as the "configuration of last resort" and "required configurations"
documentation, for http-poster; it needs these configurations because
it uses Servo counters and timers.