### PR TITLE
Bump the versions of haystack-metrics, haystack-log4j-metrics-appender,

### DIFF
--- a/firehose-writer/src/main/resources/log4j2.yaml
+++ b/firehose-writer/src/main/resources/log4j2.yaml
@@ -7,9 +7,9 @@ Configuration:
       target: SYSTEM_OUT
     EmitToGraphiteLog4jAppender:
       name: EmitToGraphiteLog4jAppender
-      subsystem: pipes
-      host: "haystack.local" # set in /etc/hosts per instructions in haystack-deployment package
-      port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
+      subsystem: pipes-firehose-writer
+      host: ${HAYSTACK_GRAPHITE_HOST}
+      port: 2003
       pollintervalseconds: 60
       queuesize: 10
       sendasrate: false

--- a/http-poster/src/main/resources/log4j2.yaml
+++ b/http-poster/src/main/resources/log4j2.yaml
@@ -7,9 +7,9 @@ Configuration:
       target: SYSTEM_OUT
     EmitToGraphiteLog4jAppender:
       name: EmitToGraphiteLog4jAppender
-      subsystem: pipes
-      host: "haystack.local" # set in /etc/hosts per instructions in haystack-deployment package
-      port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
+      subsystem: pipes-http-poster
+      host: ${HAYSTACK_GRAPHITE_HOST}
+      port: 2003
       pollintervalseconds: 60
       queuesize: 10
       sendasrate: false

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
         <commons-pool2-version>2.5.0</commons-pool2-version>
         <commons-text-version>1.1</commons-text-version>
         <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
-        <haystack-metrics-version>0.6.0</haystack-metrics-version>
-        <haystack-logback-metrics-appender-version>0.1.11</haystack-logback-metrics-appender-version>
-        <haystack-log4j-metrics-appender-version>0.1.7</haystack-log4j-metrics-appender-version>
+        <haystack-metrics-version>0.7.0</haystack-metrics-version>
+        <haystack-logback-metrics-appender-version>0.1.12</haystack-logback-metrics-appender-version>
+        <haystack-log4j-metrics-appender-version>0.1.8</haystack-log4j-metrics-appender-version>
         <haystack-pipes-commons-version>1.0-SNAPSHOT</haystack-pipes-commons-version>
         <jacoco-maven-plugin-version>0.8.0</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>


### PR DESCRIPTION
and haystack-logback-metrics-appender, all to pick up the change in
haystack-metrics to support the environment variable override of
HAYSTACK_GRAPHITE_HOST. Change log4j2.yaml to use
${HAYSTACK_GRAPHITE_HOST}. This should make the custom appender work in
http-poster and firehose-writer.