### PR TITLE
Don't close Kafka Streams in the uncaught exception handler.

### DIFF
--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/SystemExitUncaughtExceptionHandler.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/SystemExitUncaughtExceptionHandler.java
@@ -52,7 +52,6 @@ public class SystemExitUncaughtExceptionHandler implements Thread.UncaughtExcept
     @Override
     public void uncaughtException(Thread thread, Throwable throwable) {
         logger.error(String.format(ERROR_MSG, thread), throwable);
-        kafkaStreams.close();
         shutdownLogger(LOGBACK_METHOD_NAME, LOG4J_METHOD_NAME);
         factory.getRuntime().exit(SYSTEM_EXIT_STATUS);
     }

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/SystemExitUncaughtExceptionHandlerTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/SystemExitUncaughtExceptionHandlerTest.java
@@ -103,7 +103,6 @@ public class SystemExitUncaughtExceptionHandlerTest {
         verify(mockFactory).getRuntime();
         verify(mockFactory).getILoggerFactory();
         verify(mockRuntime).exit(SYSTEM_EXIT_STATUS);
-        verify(mockKafkaStreams).close();
     }
 
     @Test


### PR DESCRIPTION
We have observed close() timing out when firehose-writer runs out of
memory; this change should allow the JVM to shut down cleanly when
it runs out of memory and thereby be restarted successfully by k8s.