### PR TITLE
Initialize record list with its maximum size (500) to avoid garbage

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseAction.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseAction.java
@@ -83,7 +83,7 @@ public class FirehoseAction implements ForeachAction<String, Span> {
                 PutRecordBatchResult result = null;
                 final Stopwatch stopwatch = putBatchRequestTimer.start();
                 try {
-                    factory.createSleeper().sleep(retryCount * 1000);
+                    factory.createSleeper().sleep(((1 << retryCount) * 1000) - 1000); // 0s,1s,3s,7s,15s,31s...
                     result = amazonKinesisFirehose.putRecordBatch(request);
                     exceptionForErrorLogging.set(null); // success! clear the exception if this was a retry
                 } catch (Exception exception) {

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
@@ -47,7 +47,7 @@ class FirehoseCollector {
     }
 
     private void initialize() {
-        records = new ArrayList<>();
+        records = new ArrayList<>(MAX_RECORDS_IN_BATCH);
         totalDataSizeOfRecords = 0;
     }
 

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseActionTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseActionTest.java
@@ -150,7 +150,7 @@ public class FirehoseActionTest {
     @Test
     public void testApplyExceptionAlways() throws InterruptedException {
         final RuntimeException testException = new RuntimeException("testApplyExceptionAlways");
-        final int retryCount = 3;
+        final int retryCount = 4;
         commonWhensForTestApply(retryCount);
         when(mockAmazonKinesisFirehose.putRecordBatch(any(PutRecordBatchRequest.class)))
                 .thenThrow(testException);
@@ -160,7 +160,8 @@ public class FirehoseActionTest {
         commonVerifiesForTestApply();
         commonVerifiesForTestApplyNotEmpty(retryCount, 0);
         verify(mockSleeper).sleep(1000);
-        verify(mockSleeper).sleep(2000);
+        verify(mockSleeper).sleep(3000);
+        verify(mockSleeper).sleep(7000);
         for(int i = 0 ; i < retryCount ; i++) {
             verify(mockLogger).warn(String.format(PUT_RECORD_BATCH_WARN_MSG, i), testException);
         }


### PR DESCRIPTION
creation when growing the list. Make retry sleep back exponential.