### PR TITLE
Add thread count configuration for Kafka Streams; add synchronized

### DIFF
--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfig.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfig.java
@@ -24,4 +24,6 @@ public interface KafkaConfig {
     String fromtopic();
 
     String totopic();
+
+    int threadcount();
 }

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfigurationProvider.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfigurationProvider.java
@@ -49,4 +49,9 @@ public class KafkaConfigurationProvider implements KafkaConfig {
     public String totopic() {
         return kafkaConfig.totopic();
     }
+
+    @Override
+    public int threadcount() {
+        return kafkaConfig.threadcount();
+    }
 }

--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarter.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarter.java
@@ -71,6 +71,7 @@ public class KafkaStreamStarter {
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, containingClass.getSimpleName());
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaIpAnPort());
         props.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, getReplicationFactor());
+        props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, getThreadCount());
         props.put(StreamsConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);
         return props;
     }
@@ -88,6 +89,11 @@ public class KafkaStreamStarter {
     private String getKafkaToTopic() {
         final KafkaConfig kafkaConfig = getKafkaConfig();
         return kafkaConfig.totopic();
+    }
+
+    private int getThreadCount() {
+        final KafkaConfig kafkaConfig = getKafkaConfig();
+        return kafkaConfig.threadcount();
     }
 
     private int getReplicationFactor() {

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ConfigurationTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/ConfigurationTest.java
@@ -26,10 +26,13 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 
 public class ConfigurationTest {
+    public final static int THREAD_COUNT_CONFIGURATION_IN_TEST_BASE_DOT_YAML = 42;
+
     private final static String HAYSTACK_KAFKA_BROKERS = "haystack.kafka.brokers";
     private final static String HAYSTACK_KAFKA_FROM_TOPIC = "haystack.kafka.fromtopic";
     private final static String HAYSTACK_KAFKA_PORT = "haystack.kafka.port";
     private final static String HAYSTACK_KAFKA_TO_TOPIC = "haystack.kafka.totopic";
+    private final static String HAYSTACK_KAFKA_THREAD_COUNT = "haystack.kafka.threadcount";
     private final static String HAYSTACK_PIPE_STREAMS_REPLICATION_FACTOR = "haystack.pipe.streams.replicationfactor";
     private final static String HAYSTACK_GRAPHITE_PREFIX = "haystack.graphite.prefix";
     private final static String HAYSTACK_GRAPHITE_HOST = "haystack.graphite.host";
@@ -41,6 +44,7 @@ public class ConfigurationTest {
             {HAYSTACK_KAFKA_FROM_TOPIC, HAYSTACK_KAFKA_FROM_TOPIC},
             {HAYSTACK_KAFKA_PORT, 65534},
             {HAYSTACK_KAFKA_TO_TOPIC, HAYSTACK_KAFKA_TO_TOPIC},
+            {HAYSTACK_KAFKA_THREAD_COUNT, THREAD_COUNT_CONFIGURATION_IN_TEST_BASE_DOT_YAML},
             {HAYSTACK_PIPE_STREAMS_REPLICATION_FACTOR, 2147483645},
             {HAYSTACK_GRAPHITE_PREFIX, HAYSTACK_GRAPHITE_PREFIX},
             {HAYSTACK_GRAPHITE_HOST, HAYSTACK_GRAPHITE_HOST},

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfigurationProviderTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaConfigurationProviderTest.java
@@ -19,6 +19,7 @@ package com.expedia.www.haystack.pipes.commons.kafka;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.expedia.www.haystack.pipes.commons.ConfigurationTest.THREAD_COUNT_CONFIGURATION_IN_TEST_BASE_DOT_YAML;
 import static org.junit.Assert.assertEquals;
 
 public class KafkaConfigurationProviderTest {
@@ -47,5 +48,10 @@ public class KafkaConfigurationProviderTest {
     @Test
     public void testToTopic() {
         assertEquals("haystack.kafka.totopic", kafkaConfigurationProvider.totopic());
+    }
+
+    @Test
+    public void testThreadCount() {
+        assertEquals(THREAD_COUNT_CONFIGURATION_IN_TEST_BASE_DOT_YAML, kafkaConfigurationProvider.threadcount());
     }
 }

--- a/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarterTest.java
+++ b/commons/src/test/java/com/expedia/www/haystack/pipes/commons/kafka/KafkaStreamStarterTest.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import static com.expedia.www.haystack.pipes.commons.ConfigurationTest.THREAD_COUNT_CONFIGURATION_IN_TEST_BASE_DOT_YAML;
 import static com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter.STARTED_MSG;
 import static com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter.STARTING_MSG;
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
@@ -118,12 +119,13 @@ public class KafkaStreamStarterTest {
     @Test
     public void testGetProperties() {
         final Properties properties = kafkaStreamStarter.getProperties();
-        assertEquals(6, properties.size());
+        assertEquals(7, properties.size());
         assertEquals(CLIENT_ID, properties.get(StreamsConfig.CLIENT_ID_CONFIG));
         assertEquals(mockKafkaStreamBuilder.getClass().getName(), properties.get(ConsumerConfig.GROUP_ID_CONFIG));
         assertEquals(mockKafkaStreamBuilder.getClass().getSimpleName(), properties.get(StreamsConfig.APPLICATION_ID_CONFIG));
         assertEquals(KAFKA_IP_AND_PORT, properties.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG));
         assertEquals(2147483645, properties.get(StreamsConfig.REPLICATION_FACTOR_CONFIG));
+        assertEquals(THREAD_COUNT_CONFIGURATION_IN_TEST_BASE_DOT_YAML, properties.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG));
         assertEquals(WallclockTimestampExtractor.class, properties.get(StreamsConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG));
     }
 
@@ -141,11 +143,11 @@ public class KafkaStreamStarterTest {
 
         realFactory.createKafkaStreams(mockKStreamBuilder, kafkaStreamStarter);
 
-        verify(mockKStreamBuilder).latestResetTopicsPattern();
-        verify(mockKStreamBuilder).earliestResetTopicsPattern();
+        verify(mockKStreamBuilder, times(THREAD_COUNT_CONFIGURATION_IN_TEST_BASE_DOT_YAML)).latestResetTopicsPattern();
+        verify(mockKStreamBuilder, times(THREAD_COUNT_CONFIGURATION_IN_TEST_BASE_DOT_YAML)).earliestResetTopicsPattern();
         verify(mockKStreamBuilder, times(2)).globalStateStores();
         verify(mockKStreamBuilder).buildGlobalStateTopology();
-        verify(mockKStreamBuilder).sourceTopicPattern();
+        verify(mockKStreamBuilder, times(THREAD_COUNT_CONFIGURATION_IN_TEST_BASE_DOT_YAML)).sourceTopicPattern();
     }
 
     @Test

--- a/commons/src/test/resources/base.yaml
+++ b/commons/src/test/resources/base.yaml
@@ -4,6 +4,7 @@ haystack:
      port: 65534
      fromtopic: "haystack.kafka.fromtopic"
      totopic: "haystack.kafka.totopic"
+     threadcount: 42
   pipe:
     streams:
       replicationfactor: 2147483645

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
@@ -65,7 +65,7 @@ class FirehoseCollector {
         return shouldCreateNewBatchDueToDataSize(record) || shouldCreateNewBatchDueToRecordCount();
     }
 
-    List<Record> addRecordAndReturnBatch(Record record) {
+    synchronized List<Record> addRecordAndReturnBatch(Record record) {
         final List<Record> records;
         if (shouldCreateNewBatch(record)) {
             records = this.records;

--- a/firehose-writer/src/main/resources/base.yaml
+++ b/firehose-writer/src/main/resources/base.yaml
@@ -4,6 +4,7 @@ haystack:
      port: 9092 # default Kafka port, rarely overridden, but can be overridden by env variable
      fromtopic: "proto-spans"
      totopic: "" # not used but must be specified as empty for shared YAML parsing to work
+     threadcount: 1
   pipe:
     streams:
       replicationfactor: 1

--- a/http-poster/src/main/resources/base.yaml
+++ b/http-poster/src/main/resources/base.yaml
@@ -4,6 +4,7 @@ haystack:
      port: 9092 # default Kafka port, rarely overridden, but can be overridden by env variable
      fromtopic: "proto-spans"
      totopic: "" # not used but must be specified as empty for shared YAML parsing to work
+     threadcount: 1
   pipe:
     streams:
       replicationfactor: 1

--- a/http-poster/src/test/resources/base.yaml
+++ b/http-poster/src/test/resources/base.yaml
@@ -4,6 +4,7 @@ haystack:
      port: 9092 # default Kafka port, rarely overridden, but can be overridden by env variable
      fromtopic: "proto-spans"
      totopic: "" # not used but must be specified as empty for shared YAML parsing to work
+     threadcount: 1
   pipe:
     streams:
       replicationfactor: 1

--- a/json-transformer/src/main/resources/base.yaml
+++ b/json-transformer/src/main/resources/base.yaml
@@ -4,6 +4,7 @@ haystack:
      port: 9092 # default Kafka port, rarely overridden, but can be overridden by env variable
      fromtopic: "proto-spans"
      totopic: "json-spans"
+     threadcount: 1
   pipe:
     streams:
       replicationfactor: 1

--- a/json-transformer/src/test/resources/base.yaml
+++ b/json-transformer/src/test/resources/base.yaml
@@ -4,6 +4,7 @@ haystack:
      port: 9092 # default Kafka port, rarely overridden, but can be overridden by env variable
      fromtopic: "proto-spans"
      totopic: "json-spans"
+     threadcount: 1
   pipe:
     streams:
       replicationfactor: 1

--- a/kafka-producer/src/main/resources/base.yaml
+++ b/kafka-producer/src/main/resources/base.yaml
@@ -4,6 +4,7 @@ haystack:
      port: 9092 # default Kafka port, rarely overridden, but can be overridden by env variable
      fromtopic: "proto-spans"
      totopic: "" # not used but must be specified as empty for shared YAML parsing to work
+     threadcount: 1
   pipe:
     streams:
       replicationfactor: 1

--- a/kafka-producer/src/test/resources/base.yaml
+++ b/kafka-producer/src/test/resources/base.yaml
@@ -4,6 +4,7 @@ haystack:
      port: 9092
      fromtopic: "json-spans"
      totopic: ""
+     threadcount: 1
   pipe:
     streams:
       replicationfactor: 1


### PR DESCRIPTION
keyword to FirehoseCollector.addRecordAndReturnBatch() so that the
singleton object can handle more than one kstream thread.