### PR TITLE
Use KStreams Producer infrastructure instead of ForeachAction.

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/Batch.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/Batch.java
@@ -74,6 +74,10 @@ class Batch {
         }
     }
 
+    List<Record> getRecordListForShutdown() {
+        return firehoseCollector.returnIncompleteBatch();
+    }
+
     List<Record> extractFailedRecords(
             PutRecordBatchRequest request, PutRecordBatchResult result, int retryCount) {
         final List<Record> recordsNeedingRetry;

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
@@ -78,6 +78,12 @@ class FirehoseCollector {
         return records;
     }
 
+    List<Record> returnIncompleteBatch() {
+        final List<Record> records = this.records;
+        initialize();
+        return records;
+    }
+
     private void addRecord(Record record) {
         records.add(record);
         totalDataSizeOfRecords += record.getData().array().length;

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplier.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplier.java
@@ -1,0 +1,44 @@
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
+import com.expedia.open.tracing.Span;
+import com.netflix.servo.monitor.Timer;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FirehoseProcessorSupplier implements ProcessorSupplier<String, Span> {
+    private final Logger firehoseProcessorLogger;
+    private final Counters counters;
+    private final Timer timer;
+    private final Batch batch;
+    private final AmazonKinesisFirehose amazonKinesisFirehose;
+    private final FirehoseProcessor.Factory firehoseProcessorFactory;
+    private final FirehoseConfigurationProvider firehoseConfigurationProvider;
+
+    @Autowired
+    public FirehoseProcessorSupplier(Logger firehoseProcessorLogger,
+                                     Counters counters,
+                                     Timer timer,
+                                     Batch batch,
+                                     AmazonKinesisFirehose amazonKinesisFirehose,
+                                     FirehoseProcessor.Factory firehoseProcessorFactory,
+                                     FirehoseConfigurationProvider firehoseConfigurationProvider) {
+        this.firehoseProcessorLogger = firehoseProcessorLogger;
+        this.counters = counters;
+        this.timer = timer;
+        this.batch = batch;
+        this.amazonKinesisFirehose = amazonKinesisFirehose;
+        this.firehoseProcessorFactory = firehoseProcessorFactory;
+        this.firehoseConfigurationProvider = firehoseConfigurationProvider;
+    }
+
+    @Override
+    public Processor<String, Span> get() {
+        return new FirehoseProcessor(firehoseProcessorLogger, counters, timer, batch, amazonKinesisFirehose,
+                firehoseProcessorFactory, firehoseConfigurationProvider);
+    }
+}

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/ProtobufToFirehoseProducer.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/ProtobufToFirehoseProducer.java
@@ -23,13 +23,15 @@ import com.expedia.www.haystack.pipes.commons.serialization.SpanSerdeFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import static com.expedia.www.haystack.pipes.firehoseWriter.Constants.APPLICATION;
+
 @Component
 class ProtobufToFirehoseProducer extends KafkaStreamBuilderBase {
     @Autowired
     ProtobufToFirehoseProducer(KafkaStreamStarter kafkaStreamStarter,
                                SpanSerdeFactory spanSerdeFactory,
-                               FirehoseAction firehoseAction,
+                               FirehoseProcessorSupplier firehoseProcessorSupplier,
                                KafkaConfigurationProvider kafkaConfigurationProvider) {
-        super(kafkaStreamStarter, spanSerdeFactory, Constants.APPLICATION, kafkaConfigurationProvider, firehoseAction);
+        super(kafkaStreamStarter, spanSerdeFactory, APPLICATION, kafkaConfigurationProvider, firehoseProcessorSupplier);
     }
 }

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/BatchTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/BatchTest.java
@@ -120,6 +120,15 @@ public class BatchTest {
         assertArrayEquals(JSON_SPAN_STRING_WITH_NO_TAGS.getBytes(), byteBuffer.array());
     }
 
+    @Test
+    public void testGetRecordListForShutdown() {
+        when(mockFirehoseCollector.returnIncompleteBatch()).thenReturn(mockRecordList);
+
+        assertSame(mockRecordList, batch.getRecordListForShutdown());
+
+        verify(mockFirehoseCollector).returnIncompleteBatch();
+    }
+
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     public void testExtractFailedRecordsNonNullResult() {

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollectorTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollectorTest.java
@@ -104,4 +104,14 @@ public class FirehoseCollectorTest {
 
         verify(mockRecord, times(2 * recordCount + 1)).getData();
     }
+
+    @Test
+    public void testReturnIncompleteBatch() {
+        testShouldCreateNewBatch(MAX_RECORDS_IN_BATCH / 2, false);
+
+        final List<Record> batch = firehoseCollector.returnIncompleteBatch();
+
+        assertEquals(MAX_RECORDS_IN_BATCH / 2, batch.size());
+        assertEquals(0, firehoseCollector.returnIncompleteBatch().size());
+    }
 }

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplierTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplierTest.java
@@ -1,0 +1,62 @@
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import com.netflix.servo.monitor.Timer;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static com.expedia.www.haystack.pipes.firehoseWriter.FirehoseProcessor.STARTUP_MESSAGE;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FirehoseProcessorSupplierTest {
+    private static final String STREAM_NAME = RANDOM.nextLong() + "STREAM_NAME";
+
+    @Mock
+    private Logger mockFirehoseProcessorLogger;
+    @Mock
+    private Counters mockCounters;
+    @Mock
+    private Timer mockTimer;
+    @Mock
+    private Batch mockBatch;
+    @Mock
+    private AmazonKinesisFirehose mockAmazonKinesisFirehose;
+    @Mock
+    private FirehoseProcessor.Factory mockFirehoseProcessorFactory;
+    @Mock
+    private FirehoseConfigurationProvider mockFirehoseConfigurationProvider;
+
+    private FirehoseProcessorSupplier firehoseProcessorSupplier;
+
+    @Before
+    public void setUp() {
+        firehoseProcessorSupplier = new FirehoseProcessorSupplier(mockFirehoseProcessorLogger, mockCounters, mockTimer,
+                mockBatch, mockAmazonKinesisFirehose, mockFirehoseProcessorFactory, mockFirehoseConfigurationProvider);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockFirehoseProcessorLogger, mockCounters, mockTimer, mockBatch,
+                mockAmazonKinesisFirehose, mockFirehoseProcessorFactory, mockFirehoseConfigurationProvider);
+    }
+
+    @Test
+    public void testGet() {
+        when(mockFirehoseConfigurationProvider.streamname()).thenReturn(STREAM_NAME);
+
+        assertNotNull(firehoseProcessorSupplier.get());
+
+        verify(mockFirehoseConfigurationProvider).streamname();
+        verify(mockFirehoseProcessorLogger).info(String.format(STARTUP_MESSAGE, STREAM_NAME));
+    }
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/ProtobufToFirehoseProducerTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/ProtobufToFirehoseProducerTest.java
@@ -50,7 +50,7 @@ public class ProtobufToFirehoseProducerTest {
     @Mock
     private SpanSerdeFactory mockSpanSerdeFactory;
     @Mock
-    private FirehoseAction mockFirehoseAction;
+    private FirehoseProcessorSupplier mockFirehoseProcessorSupplier;
     @Mock
     private KafkaConfigurationProvider mockKafkaConfigurationProvider;
     @Mock
@@ -64,13 +64,13 @@ public class ProtobufToFirehoseProducerTest {
 
     @Before
     public void setUp() {
-        protobufToFirehoseProducer = new ProtobufToFirehoseProducer(
-                mockKafkaStreamStarter, mockSpanSerdeFactory, mockFirehoseAction, mockKafkaConfigurationProvider);
+        protobufToFirehoseProducer = new ProtobufToFirehoseProducer(mockKafkaStreamStarter, mockSpanSerdeFactory,
+                mockFirehoseProcessorSupplier, mockKafkaConfigurationProvider);
     }
 
     @After
     public void tearDown() {
-        verifyNoMoreInteractions(mockKafkaStreamStarter, mockSpanSerdeFactory, mockFirehoseAction,
+        verifyNoMoreInteractions(mockKafkaStreamStarter, mockSpanSerdeFactory, mockFirehoseProcessorSupplier,
                 mockKafkaConfigurationProvider, mockKStreamBuilder, mockKStream, mockSpanSerde);
     }
 
@@ -94,6 +94,6 @@ public class ProtobufToFirehoseProducerTest {
         verify(mockSpanSerdeFactory).createSpanSerde(APPLICATION);
         verify(mockKafkaConfigurationProvider).fromtopic();
         verify(mockKStreamBuilder).stream(any(Serdes.StringSerde.class), eq(mockSpanSerde), eq(FROM_TOPIC));
-        verify(mockKStream).foreach(mockFirehoseAction);
+        verify(mockKStream).process(mockFirehoseProcessorSupplier);
     }
 }

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
@@ -78,7 +78,7 @@ public class SpringConfigTest {
         assertNotNull(springConfig.spanCounter());
 
         verify(mockMetricObjects).createAndRegisterResettingCounter(SUBSYSTEM, APPLICATION,
-                FirehoseAction.class.getName(), "REQUEST");
+                FirehoseProcessor.class.getName(), "REQUEST");
     }
 
     @Test
@@ -89,7 +89,7 @@ public class SpringConfigTest {
         assertNotNull(springConfig.successCounter());
 
         verify(mockMetricObjects).createAndRegisterResettingCounter(SUBSYSTEM, APPLICATION,
-                FirehoseAction.class.getName(), "SUCCESS");
+                FirehoseProcessor.class.getName(), "SUCCESS");
     }
 
     @Test
@@ -100,7 +100,7 @@ public class SpringConfigTest {
         assertNotNull(springConfig.failureCounter());
 
         verify(mockMetricObjects).createAndRegisterResettingCounter(SUBSYSTEM, APPLICATION,
-                FirehoseAction.class.getName(), "FAILURE");
+                FirehoseProcessor.class.getName(), "FAILURE");
     }
 
     @Test
@@ -110,7 +110,7 @@ public class SpringConfigTest {
 
         assertNotNull(springConfig.putBatchRequestTimer());
 
-        verify(mockMetricObjects).createAndRegisterBasicTimer(SUBSYSTEM, APPLICATION, FirehoseAction.class.getName(),
+        verify(mockMetricObjects).createAndRegisterBasicTimer(SUBSYSTEM, APPLICATION, FirehoseProcessor.class.getName(),
                 "PUT_BATCH_REQUEST", TimeUnit.MICROSECONDS);
     }
 
@@ -124,9 +124,9 @@ public class SpringConfigTest {
 
     @Test
     public void testFirehoseActionLogger() {
-        final Logger logger = springConfig.firehoseActionLogger();
+        final Logger logger = springConfig.firehoseProcessorLogger();
 
-        assertEquals(FirehoseAction.class.getName(), logger.getName());
+        assertEquals(FirehoseProcessor.class.getName(), logger.getName());
     }
 
     @Test
@@ -186,7 +186,7 @@ public class SpringConfigTest {
     }
 
     // All of the other beans in SpringConfig use default constructors, or use arguments provided by other Spring beans
-    // in SpringConfig, so tests on the methods that create those beans have little value. The firehoseAction() Bean
+    // in SpringConfig, so tests on the methods that create those beans have little value. The firehoseProcessor() Bean
     // method should be tested but is difficult to test because of how deeply the AWS SDK code hides the instance
     // variables.
 }


### PR DESCRIPTION
This permits more efficient CPU utilization for the stateful KStreams beans.