### PR TITLE
Count exceptions in Fireshose to learn if we're being throttled.

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
@@ -65,7 +65,8 @@ class FirehoseCollector {
         return shouldCreateNewBatchDueToDataSize(record) || shouldCreateNewBatchDueToRecordCount();
     }
 
-    synchronized List<Record> addRecordAndReturnBatch(Record record) {
+    @VisibleForTesting
+    List<Record> addRecordAndReturnBatch(Record record) {
         final List<Record> records;
         if (shouldCreateNewBatch(record)) {
             records = this.records;

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplier.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplier.java
@@ -2,7 +2,6 @@ package com.expedia.www.haystack.pipes.firehoseWriter;
 
 import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
 import com.expedia.open.tracing.Span;
-import com.netflix.servo.monitor.Timer;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.slf4j.Logger;
@@ -12,8 +11,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class FirehoseProcessorSupplier implements ProcessorSupplier<String, Span> {
     private final Logger firehoseProcessorLogger;
-    private final Counters counters;
-    private final Timer timer;
+    private final FirehoseCountersAndTimer firehoseCountersAndTimer;
     private final Batch batch;
     private final AmazonKinesisFirehose amazonKinesisFirehose;
     private final FirehoseProcessor.Factory firehoseProcessorFactory;
@@ -21,15 +19,13 @@ public class FirehoseProcessorSupplier implements ProcessorSupplier<String, Span
 
     @Autowired
     public FirehoseProcessorSupplier(Logger firehoseProcessorLogger,
-                                     Counters counters,
-                                     Timer timer,
+                                     FirehoseCountersAndTimer firehoseCountersAndTimer,
                                      Batch batch,
                                      AmazonKinesisFirehose amazonKinesisFirehose,
                                      FirehoseProcessor.Factory firehoseProcessorFactory,
                                      FirehoseConfigurationProvider firehoseConfigurationProvider) {
         this.firehoseProcessorLogger = firehoseProcessorLogger;
-        this.counters = counters;
-        this.timer = timer;
+        this.firehoseCountersAndTimer = firehoseCountersAndTimer;
         this.batch = batch;
         this.amazonKinesisFirehose = amazonKinesisFirehose;
         this.firehoseProcessorFactory = firehoseProcessorFactory;
@@ -38,7 +34,7 @@ public class FirehoseProcessorSupplier implements ProcessorSupplier<String, Span
 
     @Override
     public Processor<String, Span> get() {
-        return new FirehoseProcessor(firehoseProcessorLogger, counters, timer, batch, amazonKinesisFirehose,
+        return new FirehoseProcessor(firehoseProcessorLogger, firehoseCountersAndTimer, batch, amazonKinesisFirehose,
                 firehoseProcessorFactory, firehoseConfigurationProvider);
     }
 }

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplierTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplierTest.java
@@ -24,7 +24,7 @@ public class FirehoseProcessorSupplierTest {
     @Mock
     private Logger mockFirehoseProcessorLogger;
     @Mock
-    private Counters mockCounters;
+    private FirehoseCountersAndTimer mockFirehoseCountersAndTimer;
     @Mock
     private Timer mockTimer;
     @Mock
@@ -40,13 +40,13 @@ public class FirehoseProcessorSupplierTest {
 
     @Before
     public void setUp() {
-        firehoseProcessorSupplier = new FirehoseProcessorSupplier(mockFirehoseProcessorLogger, mockCounters, mockTimer,
+        firehoseProcessorSupplier = new FirehoseProcessorSupplier(mockFirehoseProcessorLogger, mockFirehoseCountersAndTimer,
                 mockBatch, mockAmazonKinesisFirehose, mockFirehoseProcessorFactory, mockFirehoseConfigurationProvider);
     }
 
     @After
     public void tearDown() {
-        verifyNoMoreInteractions(mockFirehoseProcessorLogger, mockCounters, mockTimer, mockBatch,
+        verifyNoMoreInteractions(mockFirehoseProcessorLogger, mockFirehoseCountersAndTimer, mockTimer, mockBatch,
                 mockAmazonKinesisFirehose, mockFirehoseProcessorFactory, mockFirehoseConfigurationProvider);
     }
 


### PR DESCRIPTION
Remove synchronized keyword from method now that we're not sharing buffer.
Simplify counters/timer use in Firehose by extending CountersAndTimer.