### PR TITLE
Put back the synchronized keyword on the method addRecordAndReturnBat…

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
@@ -66,7 +66,7 @@ class FirehoseCollector {
     }
 
     @VisibleForTesting
-    List<Record> addRecordAndReturnBatch(Record record) {
+    synchronized List<Record> addRecordAndReturnBatch(Record record) {
         final List<Record> records;
         if (shouldCreateNewBatch(record)) {
             records = this.records;
@@ -79,7 +79,8 @@ class FirehoseCollector {
         return records;
     }
 
-    List<Record> returnIncompleteBatch() {
+    @VisibleForTesting
+    synchronized List<Record> returnIncompleteBatch() {
         final List<Record> records = this.records;
         initialize();
         return records;


### PR DESCRIPTION
…ch(),

because the change resulted in an ArrayIndexOutOfBoundsException. I suspect
some subtle bug in the Java memory model is responsible for this breakage.
Also made returnIncompleteBatch() synchronized as well; this method only
runs on shutdown but it seemed more consistent to have both methods
synchronized.