### PR TITLE
Set KafkaStreams class's log level to INFO, to see a "Started Kafks

### DIFF
--- a/secret-detector/src/main/resources/logback.xml
+++ b/secret-detector/src/main/resources/logback.xml
@@ -11,6 +11,9 @@
         <host>${HAYSTACK_GRAPHITE_HOST}</host>
         <subsystem>pipes-secret-detector</subsystem>
     </appender>
+    <logger name="org.apache.kafka.streams.KafkaStreams" additivity="false" level="INFO">
+        <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
+    </logger>
     <logger name="com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter" additivity="false" level="INFO">
         <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
     </logger>


### PR DESCRIPTION
Stream process" message when KafkaStreams.start() is called.