### PR TITLE
Comment out the configuration that turns on the

### DIFF
--- a/secret-detector/src/main/resources/finders_default.xml
+++ b/secret-detector/src/main/resources/finders_default.xml
@@ -14,10 +14,12 @@
 		<pattern>(\D|^)[0-9]{3}[\)\ \-\.]{1,2}[0-9]{3}[\-\ \.][0-9]{4}(\D|$)</pattern>
 		<enabled>true</enabled>
 	</finder>
+	<!--
 	<finder>
 		<class>com.expedia.www.haystack.pipes.secretDetector.actions.NonLocalIpV4AddressFinder</class>
 		<enabled>true</enabled>
 	</finder>
+	-->
 	<finder>
 		<name>Street Address</name>
 		<pattern>(\W|_|^)\d+(\s[A-Z0-9\.]+?){1,3}\s(RD|ROAD|DR|DRIVE|AVE|AVENUE|APT|APARTMENT|PL|PLACE|ST|STREET)(\W|_|$)</pattern>


### PR DESCRIPTION
NonLocalIpV4AddressFinder, since there are so many instances of IP V4
addresses being sent to Haystack.