### PR TITLE
Add a HaystackCompositeCreditCardFinder class; the

### DIFF
--- a/commons/src/main/java/com/expedia/www/haystack/pipes/commons/test/TestConstantsAndCommonCode.java
+++ b/commons/src/main/java/com/expedia/www/haystack/pipes/commons/test/TestConstantsAndCommonCode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.commons.test;
 
 import com.expedia.open.tracing.Span;
@@ -71,6 +87,9 @@ public interface TestConstantsAndCommonCode {
     Span EMAIL_ADDRESS_IN_TAG_BYTES_SPAN = buildSpan(JSON_SPAN_STRING_WITH_EMAIL_ADDRESS_IN_TAG_BYTES_AND_LOG_BYTES);
     String JSON_SPAN_STRING_WITH_EMAIL_ADDRESS_IN_LOG_TAG = JSON_SPAN_STRING.replace(STRING_FIELD_VALUE, EMAIL_ADDRESS);
     Span EMAIL_ADDRESS_LOG_SPAN = buildSpan(JSON_SPAN_STRING_WITH_EMAIL_ADDRESS_IN_LOG_TAG);
+    String CREDIT_CARD_PLUS_MORE = "9b2c3875-8960-6710-2431-bb29918e0dcf";
+    String JSON_SPAN_STRING_WITH_CREDIT_CARD_PLUS_MORE_IN_LOG_TAG = JSON_SPAN_STRING.replace(STRING_FIELD_VALUE, CREDIT_CARD_PLUS_MORE);
+    Span CREDIT_CARD_PLUS_MORE_SPAN = buildSpan(JSON_SPAN_STRING_WITH_CREDIT_CARD_PLUS_MORE_IN_LOG_TAG);
 
     static Span buildSpan(String jsonSpanString) {
         final Span.Builder builder = Span.newBuilder();

--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/HaystackCompositeCreditCardFinder.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/HaystackCompositeCreditCardFinder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.secretDetector;
+
+import io.dataapps.chlorine.finder.CompositeFinder;
+import io.dataapps.chlorine.finder.Finder;
+import io.dataapps.chlorine.pattern.CreditCardFinder;
+
+import java.util.Collection;
+import java.util.List;
+
+public class HaystackCompositeCreditCardFinder implements Finder {
+
+	private final CompositeFinder compositeFinder;
+
+	HaystackCompositeCreditCardFinder(CompositeFinder compositeFinder) {
+	    this.compositeFinder = compositeFinder;
+    }
+	/**
+	 * Like the CompositeCreditCardFinder provided by chlorine-finder, but with a START_BLOCK that avoids the false
+	 * positives that were occurring with the occasional GUID.
+	 */
+	@SuppressWarnings("unused") // used in finders_default.xml
+    public HaystackCompositeCreditCardFinder() {
+	    this(new CompositeFinder("Credit Card"));
+		String START_BLOCK = "(\\b|^)";
+		compositeFinder.add(new CreditCardFinder("Mastercard", START_BLOCK + "5[1-5][0-9]{2}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\D|$)"));
+		compositeFinder.add(new CreditCardFinder("Visa", START_BLOCK + "4[0-9]{3}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\D|$)"));
+		compositeFinder.add(new CreditCardFinder("AMEX", START_BLOCK + "(34|37)[0-9]{2}(\\ |\\-|)[0-9]{6}(\\ |\\-|)[0-9]{5}(\\D|$)"));
+		compositeFinder.add(new CreditCardFinder("Diners Club 1", START_BLOCK + "30[0-5][0-9](\\ |\\-|)[0-9]{6}(\\ |\\-|)[0-9]{4}(\\D|$)"));
+		compositeFinder.add(new CreditCardFinder("Diners Club 2", START_BLOCK + "(36|38)[0-9]{2}(\\ |\\-|)[0-9]{6}(\\ |\\-|)[0-9]{4}(\\D|$)"));
+		compositeFinder.add(new CreditCardFinder("Discover", START_BLOCK + "6011(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\D|$)"));
+		compositeFinder.add(new CreditCardFinder("JCB 1", START_BLOCK + "3[0-9]{3}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\ |\\-|)[0-9]{4}(\\D|$)"));
+		compositeFinder.add(new CreditCardFinder("JCB 2", START_BLOCK + "(2131|1800)[0-9]{11}(\\D|$)"));
+	}
+
+	@Override
+	public List<String> find(Collection<String> samples) {
+		return compositeFinder.find(samples);
+	}
+
+	@Override
+	public List<String> find(String sample) {
+		return compositeFinder.find(sample);
+	}
+
+	@Override
+	public String getName() {
+		return compositeFinder.getName();
+	}
+
+}

--- a/secret-detector/src/main/resources/finders_default.xml
+++ b/secret-detector/src/main/resources/finders_default.xml
@@ -6,7 +6,7 @@
 		<enabled>true</enabled>
 	</finder>
 	<finder>
-		<class>io.dataapps.chlorine.pattern.CompositeCreditCardFinder</class>
+		<class>com.expedia.www.haystack.pipes.secretDetector.HaystackCompositeCreditCardFinder</class>
 		<enabled>true</enabled>
 	</finder>
 	<finder>

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/DetectorTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/DetectorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.secretDetector;
 
 import com.expedia.www.haystack.pipes.secretDetector.actions.EmailerDetectedAction;
@@ -16,6 +32,7 @@ import java.util.List;
 
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.BYTES_FIELD_KEY;
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.BYTES_TAG_KEY;
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.CREDIT_CARD_PLUS_MORE_SPAN;
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.EMAIL_ADDRESS_IN_TAG_BYTES_SPAN;
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.EMAIL_ADDRESS_LOG_SPAN;
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.EMAIL_ADDRESS_SPAN;
@@ -53,7 +70,6 @@ public class DetectorTest {
 
         assertEquals(1, secrets.size());
         assertEquals(STRING_TAG_KEY, secrets.get(0));
-
     }
 
     @Test
@@ -76,6 +92,11 @@ public class DetectorTest {
     @Test
     public void testFindSecretsNoSecret() {
         assertTrue(detector.findSecrets(FULLY_POPULATED_SPAN).isEmpty());
+    }
+
+    @Test
+    public void testFindSecretsCreditCardPlusMore() {
+        assertTrue(detector.findSecrets(CREDIT_CARD_PLUS_MORE_SPAN).isEmpty());
     }
 
     @Test

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/HaystackCompositeCreditCardFinderTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/HaystackCompositeCreditCardFinderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.secretDetector;
+
+import io.dataapps.chlorine.finder.CompositeFinder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HaystackCompositeCreditCardFinderTest {
+    private static final String STRING = RANDOM.nextLong() + "STRING";
+    private static final String OUTPUT = RANDOM.nextLong() + "OUTPUT";
+    private static final List<String> OUTPUTS = Collections.singletonList(OUTPUT);
+
+    @Mock
+    private CompositeFinder mockCompositeFinder;
+
+    private HaystackCompositeCreditCardFinder haystackCompositeCreditCardFinder;
+
+    @Before
+    public void setUp() {
+        haystackCompositeCreditCardFinder = new HaystackCompositeCreditCardFinder(mockCompositeFinder);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockCompositeFinder);
+    }
+
+    @Test
+    public void testFindCollectionString() {
+        final List<String> samples = Collections.singletonList(STRING);
+        when(mockCompositeFinder.find(anyListOf(String.class))).thenReturn(OUTPUTS);
+
+        assertSame(OUTPUTS, haystackCompositeCreditCardFinder.find(samples));
+
+        verify(mockCompositeFinder).find(samples);
+    }
+
+    @Test
+    public void testFindString() {
+        when(mockCompositeFinder.find(anyString())).thenReturn(OUTPUTS);
+
+        assertSame(OUTPUTS, haystackCompositeCreditCardFinder.find(STRING));
+
+        verify(mockCompositeFinder).find(STRING);
+    }
+
+    @Test
+    public void testGetName() {
+        when(mockCompositeFinder.getName()).thenReturn(OUTPUT);
+
+        assertSame(OUTPUT, haystackCompositeCreditCardFinder.getName());
+
+        verify(mockCompositeFinder).getName();
+    }
+}


### PR DESCRIPTION
CompositeCreditCardFinder provided by chlorine-finder was producing
false positives.