### PR TITLE
Log when phone number secrets are found, to help debug false positives.

### DIFF
--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/Detector.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/Detector.java
@@ -22,6 +22,7 @@ import com.expedia.open.tracing.Tag;
 import com.expedia.www.haystack.metrics.MetricObjects;
 import com.expedia.www.haystack.pipes.secretDetector.actions.EmailerDetectedAction;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.servo.monitor.Counter;
 import io.dataapps.chlorine.finder.FinderEngine;
 import org.apache.commons.lang3.StringUtils;
@@ -45,7 +46,7 @@ import static com.expedia.www.haystack.pipes.secretDetector.Constants.APPLICATIO
  */
 @Component
 public class Detector implements ValueMapper<Span, Iterable<String>> {
-    private static final Set<String> FINDERS_TO_LOG = Collections.singleton("Credit_Card");
+    private static final Set<String> FINDERS_TO_LOG = ImmutableSet.of("Credit_Card", "US_Phone_formatted");
     @VisibleForTesting
     static final String ERRORS_METRIC_GROUP = "errors";
     @VisibleForTesting

--- a/secret-detector/src/main/resources/finders_default.xml
+++ b/secret-detector/src/main/resources/finders_default.xml
@@ -16,6 +16,7 @@
 	</finder>
 	<finder>
 		<class>com.expedia.www.haystack.pipes.secretDetector.actions.NonLocalIpV4AddressFinder</class>
+		<name>NonLocalIpV4</name>
 		<enabled>true</enabled>
 	</finder>
 	<finder>

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/DetectorTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/DetectorTest.java
@@ -266,4 +266,5 @@ public class DetectorTest {
                 = new FinderNameAndServiceName("1", "3");
         assertNotEquals(finderNameAndServiceName12.hashCode(), finderNameAndServiceName13.hashCode());
     }
+
 }


### PR DESCRIPTION
Also rename the IP finder to a shorter name to make grafana graphs more readable.