### PR TITLE
Explicitly check for alphabetic characters in phone number, as the

### DIFF
--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/HaystackPhoneNumberFinder.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/HaystackPhoneNumberFinder.java
@@ -25,10 +25,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class HaystackPhoneNumberFinder implements Finder {
     public static final String FINDER_NAME = "PhoneNumber";
     private static final String REGION = "US";
+    private static final Pattern ALPHAS_PATTERN = Pattern.compile("[A-Za-z]+");
     private final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
 
     @Override
@@ -48,13 +51,20 @@ public class HaystackPhoneNumberFinder implements Finder {
     @Override
     public List<String> find(String input) {
         try {
-            final PhoneNumber phoneNumber = phoneNumberUtil.parseAndKeepRawInput(input, REGION);
-            if(phoneNumberUtil.isValidNumberForRegion(phoneNumber, REGION)) {
-                return Collections.singletonList(phoneNumber.getRawInput());
+            if(!containsAnyAlphabeticCharacters(input)) { //
+                final PhoneNumber phoneNumber = phoneNumberUtil.parseAndKeepRawInput(input, REGION);
+                if (phoneNumberUtil.isValidNumberForRegion(phoneNumber, REGION)) {
+                    return Collections.singletonList(phoneNumber.getRawInput());
+                }
             }
         } catch (NumberParseException e) {
             // Just ignore, it's not a phone number
         }
         return Collections.emptyList();
+    }
+
+    private boolean containsAnyAlphabeticCharacters(String input) {
+        final Matcher matcher = ALPHAS_PATTERN.matcher(input);
+        return matcher.find();
     }
 }

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/HaystackPhoneNumberFinderTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/HaystackPhoneNumberFinderTest.java
@@ -36,6 +36,7 @@ public class HaystackPhoneNumberFinderTest {
 
     private static final String [] INVALID_US_PHONE_NUMBERS = {
             "4640-1234-5678-9120",
+            "/minify/min-2487701102.js",
     };
 
     private HaystackPhoneNumberFinder haystackPhoneNumberFinder;


### PR DESCRIPTION
libphonenumber package just throws them away, leaving the numbers,
resulting in false positives.