### PR TITLE
Ignore phone numbers that are only numeric, to avoid false positives

### DIFF
--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/HaystackPhoneNumberFinder.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/HaystackPhoneNumberFinder.java
@@ -32,6 +32,7 @@ public class HaystackPhoneNumberFinder implements Finder {
     public static final String FINDER_NAME = "PhoneNumber";
     private static final String REGION = "US";
     private static final Pattern ALPHAS_PATTERN = Pattern.compile("[A-Za-z]+");
+    private static final Pattern ALL_NUMBERS_PATTERN = Pattern.compile("^\\d+$");
     private final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
 
     @Override
@@ -53,9 +54,11 @@ public class HaystackPhoneNumberFinder implements Finder {
         try {
             if(!containsAnyAlphabeticCharacters(input)) {
                 if(isNotIpV4Address(input)) {
-                    final PhoneNumber phoneNumber = phoneNumberUtil.parseAndKeepRawInput(input, REGION);
-                    if (phoneNumberUtil.isValidNumberForRegion(phoneNumber, REGION)) {
-                        return Collections.singletonList(phoneNumber.getRawInput());
+                    if(!containsOnlyNumbers(input)) {
+                        final PhoneNumber phoneNumber = phoneNumberUtil.parseAndKeepRawInput(input, REGION);
+                        if (phoneNumberUtil.isValidNumberForRegion(phoneNumber, REGION)) {
+                            return Collections.singletonList(phoneNumber.getRawInput());
+                        }
                     }
                 }
             }
@@ -66,11 +69,14 @@ public class HaystackPhoneNumberFinder implements Finder {
     }
 
     private boolean containsAnyAlphabeticCharacters(String input) {
-        final Matcher matcher = ALPHAS_PATTERN.matcher(input);
-        return matcher.find();
+        return ALPHAS_PATTERN.matcher(input).find();
     }
 
     private boolean isNotIpV4Address(String input) {
         return NonLocalIpV4AddressFinder.IPV4_FINDER.find(input).isEmpty();
+    }
+
+    private boolean containsOnlyNumbers(String input) {
+        return ALL_NUMBERS_PATTERN.matcher(input).find();
     }
 }

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/HaystackPhoneNumberFinderTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/HaystackPhoneNumberFinderTest.java
@@ -30,14 +30,15 @@ import static org.junit.Assert.assertEquals;
 @RunWith(MockitoJUnitRunner.class)
 public class HaystackPhoneNumberFinderTest {
     private static final String [] VALID_US_PHONE_NUMBERS = {
-            "1-800-555-1212", "1 (800) 555-1212", "18005551212",
-            "800-555-1212", "(800) 555-1212", "8005551212",
+            "1-800-555-1212", "1 (800) 555-1212",
+            "800-555-1212", "(800) 555-1212", "800.555.1212",
     };
 
     private static final String [] INVALID_US_PHONE_NUMBERS = {
             "4640-1234-5678-9120",
             "/minify/min-2487701102.js",
             "50.242.105.69",
+            "2147483647",
     };
 
     private HaystackPhoneNumberFinder haystackPhoneNumberFinder;
@@ -59,7 +60,7 @@ public class HaystackPhoneNumberFinderTest {
     public void testFindStringValidNumbers() {
         for (String phoneNumber : VALID_US_PHONE_NUMBERS) {
             final List<String> strings = haystackPhoneNumberFinder.find(phoneNumber);
-            assertEquals(1, strings.size());
+            assertEquals(phoneNumber, 1, strings.size());
         }
     }
 


### PR DESCRIPTION
with, for example, user ID values, etc.