### PR TITLE
Use haystack-metrics 2.0.0, with the custom logger packages that

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfig.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfig.java
@@ -99,8 +99,8 @@ class SpringConfig {
 
     @Bean
     Timer putBatchRequestTimer() {
-        return metricObjects.createAndRegisterBucketTimer(SUBSYSTEM, APPLICATION, FirehoseProcessor.class.getName(),
-                "PUT_BATCH_REQUEST", TimeUnit.MILLISECONDS, BUCKETS_FOR_PUT_BATCH_REQUEST_TIMER);
+        return metricObjects.createAndRegisterBucketTimer(SUBSYSTEM, APPLICATION, "PUT_BATCH_REQUEST",
+                TimeUnit.MILLISECONDS, BUCKETS_FOR_PUT_BATCH_REQUEST_TIMER);
     }
 
     @Bean

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
@@ -134,14 +134,13 @@ public class SpringConfigTest {
 
     @Test
     public void testPutBatchRequestTimer() {
-        when(mockMetricObjects.createAndRegisterBucketTimer(anyString(), anyString(), anyString(), anyString(),
-                any(TimeUnit.class), anyVararg())).thenReturn(mockTimer);
+        when(mockMetricObjects.createAndRegisterBucketTimer(anyString(), anyString(), anyString(), any(TimeUnit.class),
+                anyVararg())).thenReturn(mockTimer);
 
         assertNotNull(springConfig.putBatchRequestTimer());
 
-        verify(mockMetricObjects).createAndRegisterBucketTimer(SUBSYSTEM, APPLICATION,
-                FirehoseProcessor.class.getName(), "PUT_BATCH_REQUEST", MILLISECONDS,
-                BUCKETS_FOR_PUT_BATCH_REQUEST_TIMER);
+        verify(mockMetricObjects).createAndRegisterBucketTimer(SUBSYSTEM, APPLICATION, "PUT_BATCH_REQUEST",
+                MILLISECONDS, BUCKETS_FOR_PUT_BATCH_REQUEST_TIMER);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
         <commons-pool2-version>2.5.0</commons-pool2-version>
         <commons-text-version>1.1</commons-text-version>
         <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
-        <haystack-metrics-version>1.0.0</haystack-metrics-version>
-        <haystack-logback-metrics-appender-version>0.1.15</haystack-logback-metrics-appender-version>
-        <haystack-log4j-metrics-appender-version>0.1.13</haystack-log4j-metrics-appender-version>
+        <haystack-metrics-version>2.0.0</haystack-metrics-version>
+        <haystack-logback-metrics-appender-version>1.0.2</haystack-logback-metrics-appender-version>
+        <haystack-log4j-metrics-appender-version>1.0.2</haystack-log4j-metrics-appender-version>
         <haystack-pipes-commons-version>1.0-SNAPSHOT</haystack-pipes-commons-version>
         <jacoco-maven-plugin-version>0.8.0</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>


### PR DESCRIPTION
also use that version, to get better support for bucket timer.