### PR TITLE
Only use the credit card finder when deploying. Put finders_default.xml

### DIFF
--- a/secret-detector/src/test/resources/finders_default.xml
+++ b/secret-detector/src/test/resources/finders_default.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <finders>
-<!--
 	<finder>
 		<name>Email</name>
 		<pattern>(\D|^)[A-Z0-9._%+-]+@([A-Z0-9.-]+)\.([A-Z]{2,4})(\D|$)</pattern>
@@ -10,12 +9,10 @@
 		<class>com.expedia.www.haystack.pipes.secretDetector.actions.HaystackPhoneNumberFinder</class>
 		<enabled>true</enabled>
 	</finder>
--->
 	<finder>
 		<class>com.expedia.www.haystack.pipes.secretDetector.HaystackCompositeCreditCardFinder</class>
 		<enabled>true</enabled>
 	</finder>
-<!--
 	<finder>
 		<name>US Phone#Formatted</name>
 		<pattern>(\D|^)[0-9]{3}[\)\ \-\.]{1,2}[0-9]{3}[\-\ \.][0-9]{4}(\D|$)</pattern>
@@ -57,5 +54,4 @@
 		<pattern><![CDATA[(\D|^)(?:(?:(?:[A-F0-9]{1,4}:){6}|(?=(?:[A-F0-9]{0,4}:){0,6}(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![:.\w]))(([0-9A-F]{1,4}:){0,5}|:)((:[0-9A-F]{1,4}){1,5}:|:)|::(?:[A-F0-9]{1,4}:){5})(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}|(?=(?:[A-F0-9]{0,4}:){0,7}[A-F0-9]{0,4}(?![:.\w]))(([0-9A-F]{1,4}:){1,7}|:)((:[0-9A-F]{1,4}){1,7}|:)|(?:[A-F0-9]{1,4}:){7}:|:(:[A-F0-9]{1,4}){7})(?![:.\w])(\D|$)]]></pattern>
 		<enabled>false</enabled>
 	</finder>
--->
 </finders>


### PR DESCRIPTION
with all detectors active into test resources to keep unit tests passing.