### PR TITLE
Changes to facilitate moving some more classes to haystack-commons:

### DIFF
--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/FinderNameAndServiceName.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/FinderNameAndServiceName.java
@@ -1,0 +1,37 @@
+package com.expedia.www.haystack.pipes.secretDetector;
+
+import java.util.Objects;
+
+public class FinderNameAndServiceName {
+    private final String finderName;
+    private final String serviceName;
+
+    FinderNameAndServiceName(String finderName, String serviceName) {
+        this.finderName = finderName;
+        this.serviceName = serviceName;
+    }
+
+    String getFinderName() {
+        return finderName;
+    }
+
+    String getServiceName() {
+        return serviceName;
+    }
+
+    // equals and hashCode are overridden with this IDE-created code so that FinderNameAndServiceName objects can
+    // be the key in the static Detector.COUNTERS object.
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FinderNameAndServiceName that = (FinderNameAndServiceName) o;
+        return Objects.equals(finderName, that.finderName) &&
+                Objects.equals(serviceName, that.serviceName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(finderName, serviceName);
+    }
+}

--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/S3ConfigFetcher.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/S3ConfigFetcher.java
@@ -22,8 +22,6 @@ import com.expedia.www.haystack.pipes.secretDetector.config.WhiteListConfig;
 import com.expedia.www.haystack.pipes.secretDetector.config.WhiteListItem;
 import com.netflix.servo.util.VisibleForTesting;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -38,7 +36,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-@Component
 public class S3ConfigFetcher {
     @VisibleForTesting
     static final String ERROR_MESSAGE = "Exception getting white list items" +
@@ -64,7 +61,6 @@ public class S3ConfigFetcher {
     @VisibleForTesting
     AtomicBoolean isUpdateInProgress = new AtomicBoolean(false);
 
-    @Autowired
     S3ConfigFetcher(Logger s3ConfigFetcherLogger,
                     WhiteListConfig whiteListConfig,
                     AmazonS3 amazonS3,

--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/SpringConfig.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/SpringConfig.java
@@ -187,11 +187,11 @@ public class SpringConfig {
 
     @Bean
     @Autowired
-    Detector detector(Logger detectorLogger,
-                      FinderEngine finderEngine,
-                      Detector.Factory detectorFactory,
-                      S3ConfigFetcher s3ConfigFetcher) {
-        return new Detector(detectorLogger, finderEngine, detectorFactory, s3ConfigFetcher);
+    SpringWiredDetector detector(Logger detectorLogger,
+                                 FinderEngine finderEngine,
+                                 Detector.Factory detectorFactory,
+                                 S3ConfigFetcher s3ConfigFetcher) {
+        return new SpringWiredDetector(detectorLogger, finderEngine, detectorFactory, s3ConfigFetcher);
     }
 
     @Bean
@@ -246,7 +246,7 @@ public class SpringConfig {
                                     WhiteListConfig whiteListConfig,
                                     AmazonS3 amazonS3,
                                     S3ConfigFetcher.Factory s3ConfigFetcherFactory) {
-        return new S3ConfigFetcher(s3ConfigFetcherLogger, whiteListConfig, amazonS3, s3ConfigFetcherFactory);
+        return new SpringWiredS3ConfigFetcher(s3ConfigFetcherLogger, whiteListConfig, amazonS3, s3ConfigFetcherFactory);
     }
 
     /*
@@ -299,6 +299,5 @@ public class SpringConfig {
         KafkaConfigurationProvider kafkaConfigurationProvider() {
             return new KafkaConfigurationProvider();
         }
-
     }
 }

--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/SpringWiredDetector.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/SpringWiredDetector.java
@@ -1,0 +1,17 @@
+package com.expedia.www.haystack.pipes.secretDetector;
+
+import io.dataapps.chlorine.finder.FinderEngine;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringWiredDetector extends Detector {
+    @Autowired
+    SpringWiredDetector(Logger detectorLogger,
+                        FinderEngine finderEngine,
+                        Factory detectorFactory,
+                        S3ConfigFetcher s3ConfigFetcher) {
+        super(detectorLogger, finderEngine, detectorFactory, s3ConfigFetcher);
+    }
+}

--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/SpringWiredS3ConfigFetcher.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/SpringWiredS3ConfigFetcher.java
@@ -1,0 +1,18 @@
+package com.expedia.www.haystack.pipes.secretDetector;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.expedia.www.haystack.pipes.secretDetector.config.WhiteListConfig;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringWiredS3ConfigFetcher extends S3ConfigFetcher {
+    @Autowired
+    SpringWiredS3ConfigFetcher(Logger s3ConfigFetcherLogger,
+                               WhiteListConfig whiteListConfig,
+                               AmazonS3 amazonS3,
+                               Factory s3ConfigFetcherFactory) {
+        super(s3ConfigFetcherLogger, whiteListConfig, amazonS3, s3ConfigFetcherFactory);
+    }
+}

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/DetectorTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/DetectorTest.java
@@ -17,11 +17,10 @@
 package com.expedia.www.haystack.pipes.secretDetector;
 
 import com.expedia.open.tracing.Span;
+import com.expedia.www.haystack.commons.secretDetector.NonLocalIpV4AddressFinder;
 import com.expedia.www.haystack.metrics.MetricObjects;
 import com.expedia.www.haystack.pipes.secretDetector.Detector.Factory;
-import com.expedia.www.haystack.pipes.secretDetector.Detector.FinderNameAndServiceName;
 import com.expedia.www.haystack.pipes.secretDetector.actions.EmailerDetectedAction;
-import com.expedia.www.haystack.commons.secretDetector.NonLocalIpV4AddressFinder;
 import com.netflix.servo.monitor.Counter;
 import io.dataapps.chlorine.finder.FinderEngine;
 import org.junit.After;
@@ -61,7 +60,6 @@ import static com.expedia.www.haystack.pipes.secretDetector.Detector.ERRORS_METR
 import static com.expedia.www.haystack.pipes.secretDetector.Detector.FINDERS_TO_LOG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -196,7 +194,7 @@ public class DetectorTest {
         if(FINDERS_TO_LOG.contains(CREDIT_CARD_FINDER_NAME)) {
             verify(mockLogger).info(emailText);
         }
-        verifyCounterIncrement(1, CREDIT_CARD_FINDER_NAME_IN_FINDERS_DEFAULT_DOT_XML);
+        verifyCounterIncrement();
     }
 
     @Test
@@ -215,11 +213,11 @@ public class DetectorTest {
                 "Email", SERVICE_NAME, OPERATION_NAME, STRING_FIELD_KEY);
     }
 
-    private void verifyCounterIncrement(int wantedNumberOfInvocations, String finderName) {
+    private void verifyCounterIncrement() {
         final FinderNameAndServiceName finderAndServiceName =
-                new FinderNameAndServiceName(finderName, SERVICE_NAME);
+                new FinderNameAndServiceName(CREDIT_CARD_FINDER_NAME_IN_FINDERS_DEFAULT_DOT_XML, SERVICE_NAME);
         verify(mockFactory).createCounter(finderAndServiceName);
-        verify(mockCounter, times(wantedNumberOfInvocations)).increment();
+        verify(mockCounter, times(1)).increment();
     }
 
     @Test
@@ -234,63 +232,4 @@ public class DetectorTest {
                 ERRORS_METRIC_GROUP, APPLICATION, FINDER_NAME, SERVICE_NAME, COUNTER_NAME);
     }
 
-    @Test
-    public void testFinderNameAndServiceNameEqualsNullOther() {
-        //noinspection SimplifiableJUnitAssertion,ConstantConditions,ObjectEqualsNull
-        assertFalse(FINDER_NAME_AND_SERVICE_NAME.equals(null));
-    }
-
-    @Test
-    public void testFinderNameAndServiceNameEqualsSameOther() {
-        assertEquals(FINDER_NAME_AND_SERVICE_NAME, FINDER_NAME_AND_SERVICE_NAME);
-    }
-
-    @Test
-    public void testFinderNameAndServiceNameEqualsDifferentClassOther() {
-        //noinspection SimplifiableJUnitAssertion,EqualsBetweenInconvertibleTypes
-        assertFalse(FINDER_NAME_AND_SERVICE_NAME.equals(FINDER_NAME));
-    }
-
-    @Test
-    public void testFinderNameAndServiceNameEqualsTotalMatch() {
-        final FinderNameAndServiceName finderNameAndServiceName
-                = new FinderNameAndServiceName(FINDER_NAME, SERVICE_NAME);
-        assertEquals(FINDER_NAME_AND_SERVICE_NAME, finderNameAndServiceName);
-    }
-
-    @Test
-    public void testFinderNameAndServiceNameEqualsFinderNameMisMatch() {
-        final FinderNameAndServiceName finderNameAndServiceName13
-                = new FinderNameAndServiceName("1", "3");
-        final FinderNameAndServiceName finderNameAndServiceName23
-                = new FinderNameAndServiceName("2", "3");
-        assertNotEquals(finderNameAndServiceName13, finderNameAndServiceName23);
-    }
-
-    @Test
-    public void testFinderNameAndServiceNameEqualsServiceNameMisMatch() {
-        final FinderNameAndServiceName finderNameAndServiceName12
-                = new FinderNameAndServiceName("1", "2");
-        final FinderNameAndServiceName finderNameAndServiceName13
-                = new FinderNameAndServiceName("1", "3");
-        assertNotEquals(finderNameAndServiceName12, finderNameAndServiceName13);
-    }
-
-    @Test
-    public void testFinderNameAndServiceNameHashCodeFinderNameMisMatch() {
-        final FinderNameAndServiceName finderNameAndServiceName13
-                = new FinderNameAndServiceName("1", "3");
-        final FinderNameAndServiceName finderNameAndServiceName23
-                = new FinderNameAndServiceName("2", "3");
-        assertNotEquals(finderNameAndServiceName13.hashCode(), finderNameAndServiceName23.hashCode());
-    }
-
-    @Test
-    public void testFinderNameAndServiceNameHashCodeServiceNameMisMatch() {
-        final FinderNameAndServiceName finderNameAndServiceName12
-                = new FinderNameAndServiceName("1", "2");
-        final FinderNameAndServiceName finderNameAndServiceName13
-                = new FinderNameAndServiceName("1", "3");
-        assertNotEquals(finderNameAndServiceName12.hashCode(), finderNameAndServiceName13.hashCode());
-    }
 }

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/FinderNameAndServiceNameTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/FinderNameAndServiceNameTest.java
@@ -1,0 +1,92 @@
+package com.expedia.www.haystack.pipes.secretDetector;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.SERVICE_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+public class FinderNameAndServiceNameTest {
+    private static final String FINDER_NAME = RANDOM.nextLong() + "FINDER_NAME";
+
+    private FinderNameAndServiceName finderNameAndServiceName;
+
+    @Before
+    public void setUp() {
+        finderNameAndServiceName = new FinderNameAndServiceName(FINDER_NAME, SERVICE_NAME);
+    }
+
+    @Test
+    public void testGetFinderName() {
+        assertEquals(FINDER_NAME, finderNameAndServiceName.getFinderName());
+    }
+
+    @Test
+    public void testGetServiceName() {
+        assertEquals(SERVICE_NAME, finderNameAndServiceName.getServiceName());
+    }
+
+    @Test
+    public void testEqualsNullOther() {
+        //noinspection SimplifiableJUnitAssertion,ConstantConditions,ObjectEqualsNull
+        assertFalse(finderNameAndServiceName.equals(null));
+    }
+
+    @Test
+    public void testEqualsSameOther() {
+        assertEquals(finderNameAndServiceName, finderNameAndServiceName);
+    }
+
+    @Test
+    public void testEqualsDifferentClassOther() {
+        //noinspection SimplifiableJUnitAssertion,EqualsBetweenInconvertibleTypes
+        assertFalse(finderNameAndServiceName.equals(FINDER_NAME));
+    }
+
+    @Test
+    public void testEqualsTotalMatch() {
+        final FinderNameAndServiceName finderNameAndServiceName
+                = new FinderNameAndServiceName(FINDER_NAME, SERVICE_NAME);
+        assertEquals(finderNameAndServiceName, finderNameAndServiceName);
+    }
+
+    @Test
+    public void testEqualsFinderNameMisMatch() {
+        final FinderNameAndServiceName finderNameAndServiceName13
+                = new FinderNameAndServiceName("1", "3");
+        final FinderNameAndServiceName finderNameAndServiceName23
+                = new FinderNameAndServiceName("2", "3");
+        assertNotEquals(finderNameAndServiceName13, finderNameAndServiceName23);
+    }
+
+    @Test
+    public void testEqualsServiceNameMisMatch() {
+        final FinderNameAndServiceName finderNameAndServiceName12
+                = new FinderNameAndServiceName("1", "2");
+        final FinderNameAndServiceName finderNameAndServiceName13
+                = new FinderNameAndServiceName("1", "3");
+        assertNotEquals(finderNameAndServiceName12, finderNameAndServiceName13);
+    }
+
+    @Test
+    public void testHashCodeFinderNameMisMatch() {
+        final FinderNameAndServiceName finderNameAndServiceName13
+                = new FinderNameAndServiceName("1", "3");
+        final FinderNameAndServiceName finderNameAndServiceName23
+                = new FinderNameAndServiceName("2", "3");
+        assertNotEquals(finderNameAndServiceName13.hashCode(), finderNameAndServiceName23.hashCode());
+    }
+
+    @Test
+    public void testHashCodeServiceNameMisMatch() {
+        final FinderNameAndServiceName finderNameAndServiceName12
+                = new FinderNameAndServiceName("1", "2");
+        final FinderNameAndServiceName finderNameAndServiceName13
+                = new FinderNameAndServiceName("1", "3");
+        assertNotEquals(finderNameAndServiceName12.hashCode(), finderNameAndServiceName13.hashCode());
+    }
+
+}


### PR DESCRIPTION
Make FinderNameAndServiceName an outer class. Remove Spring annotations
from Detector and S3ConfigFetcher. Put those Spring annotations on
new classes SpringWiredDetector and SpringWiredS3ConfigFetcher.