### PR TITLE
Remove temporary log message now that we know the correct Kafka topic

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/ProtobufToFirehoseProducer.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/ProtobufToFirehoseProducer.java
@@ -20,7 +20,6 @@ import com.expedia.www.haystack.pipes.commons.kafka.KafkaConfigurationProvider;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamBuilderBase;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter;
 import com.expedia.www.haystack.pipes.commons.serialization.SpanSerdeFactory;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,7 +33,5 @@ class ProtobufToFirehoseProducer extends KafkaStreamBuilderBase {
                                FirehoseProcessorSupplier firehoseProcessorSupplier,
                                KafkaConfigurationProvider kafkaConfigurationProvider) {
         super(kafkaStreamStarter, spanSerdeFactory, APPLICATION, kafkaConfigurationProvider, firehoseProcessorSupplier);
-        LoggerFactory.getLogger(ProtobufToFirehoseProducer.class).error(
-                "Temporary log message: fromtopic=" + kafkaConfigurationProvider.fromtopic());
     }
 }

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/ProtobufToFirehoseProducerTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/ProtobufToFirehoseProducerTest.java
@@ -37,7 +37,6 @@ import static com.expedia.www.haystack.pipes.firehoseWriter.Constants.APPLICATIO
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -79,7 +78,6 @@ public class ProtobufToFirehoseProducerTest {
     public void testMain() {
         protobufToFirehoseProducer.main();
 
-        verify(mockKafkaConfigurationProvider).fromtopic();
         verify(mockKafkaStreamStarter).createAndStartStream(protobufToFirehoseProducer);
     }
 
@@ -94,7 +92,7 @@ public class ProtobufToFirehoseProducerTest {
         protobufToFirehoseProducer.buildStreamTopology(mockKStreamBuilder);
 
         verify(mockSpanSerdeFactory).createSpanSerde(APPLICATION);
-        verify(mockKafkaConfigurationProvider, times(2)).fromtopic();
+        verify(mockKafkaConfigurationProvider).fromtopic();
         verify(mockKStreamBuilder).stream(any(Serdes.StringSerde.class), eq(mockSpanSerde), eq(FROM_TOPIC));
         verify(mockKStream).process(mockFirehoseProcessorSupplier);
     }


### PR DESCRIPTION
is being read from.