### PR TITLE
Log errors from Firehose at ERROR level instead of WARN to get insight

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/Batch.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/Batch.java
@@ -86,7 +86,7 @@ class Batch {
     }
 
     List<Record> getRecordListForShutdown() {
-        return firehoseCollector.returnIncompleteBatch();
+        return firehoseCollector.createIncompleteBatch();
     }
 
     List<Record> extractFailedRecords(
@@ -143,7 +143,7 @@ class Batch {
     void logFailures(int retryCount, Map<String, String> uniqueErrorCodesAndMessages) {
         if(!uniqueErrorCodesAndMessages.isEmpty()) {
             final String allErrorCodesAndMessages = StringUtils.join(uniqueErrorCodesAndMessages, ',');
-            logger.warn(String.format(ERROR_CODES_AND_MESSAGES_OF_FAILURES, allErrorCodesAndMessages, retryCount));
+            logger.error(String.format(ERROR_CODES_AND_MESSAGES_OF_FAILURES, allErrorCodesAndMessages, retryCount));
         }
     }
 }

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
@@ -22,7 +22,7 @@ import com.amazonaws.services.kinesisfirehose.model.Record;
 
 /**
  * Interface for implementations that buffer data to be written
- * to firehose
+ * to Firehose
  */
 public interface FirehoseCollector {
     /**
@@ -50,11 +50,11 @@ public interface FirehoseCollector {
     long LAST_BATCH_TIME_DIFF_ALLOWED_MILLIS = 3000;
 
     /**
-     * this method should buffer the given data and return a collection
+     * This method should buffer the given data and return a collection
      * of records that are ready to be dispatched as one batch to firehose
      *
-     * this method should make sure the number of records do not exceed
-     * {@link #MAX_RECORDS_IN_BATCH} or the total size of the batch do not
+     * This method should make sure the number of records does not exceed
+     * {@link #MAX_RECORDS_IN_BATCH} and that the total size of the batch does not
      * exceed {@link #MAX_BYTES_IN_BATCH}
      * @param data data to be appended to the next batch
      * @return full batch that is ready to be dispatched
@@ -62,11 +62,10 @@ public interface FirehoseCollector {
     List<Record> addRecordAndReturnBatch(String data);
 
     /**
-     * This method return the remaining data if any that has been buffered as a collection of
-     * Records to be dispatched to firehose
+     * This method returns the remaining data that has been buffered but not yet sent to Firehose.
      * @return collection of records or an empty collection
      */
-    List<Record> returnIncompleteBatch();
+    List<Record> createIncompleteBatch();
 
     class Factory {
         long currentTimeMillis() {

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseRecordBufferCollector.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseRecordBufferCollector.java
@@ -93,7 +93,8 @@ class FirehoseRecordBufferCollector implements FirehoseCollector {
         return addRecordAndReturnBatch(data.getBytes());
     }
 
-    public List<Record> returnIncompleteBatch() {
+    @Override
+    public List<Record> createIncompleteBatch() {
         final List<Record> records = this.records;
         initialize();
         return records;

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/BatchTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/BatchTest.java
@@ -136,11 +136,11 @@ public class BatchTest {
 
     @Test
     public void testGetRecordListForShutdown() {
-        when(mockFirehoseCollector.returnIncompleteBatch()).thenReturn(mockRecordList);
+        when(mockFirehoseCollector.createIncompleteBatch()).thenReturn(mockRecordList);
 
         assertSame(mockRecordList, batch.getRecordListForShutdown());
 
-        verify(mockFirehoseCollector).returnIncompleteBatch();
+        verify(mockFirehoseCollector).createIncompleteBatch();
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -175,7 +175,7 @@ public class BatchTest {
         verify(mockRecordList).get(3);
         verify(mockRecordList).get(4);
         final String uniqueErrors = "{A_once=A_message, B_twice=B_message},";
-        verify(mockLogger).warn(String.format(ERROR_CODES_AND_MESSAGES_OF_FAILURES, uniqueErrors, RETRY_COUNT));
+        verify(mockLogger).error(String.format(ERROR_CODES_AND_MESSAGES_OF_FAILURES, uniqueErrors, RETRY_COUNT));
     }
 
     @Test
@@ -190,6 +190,7 @@ public class BatchTest {
         verify(mockLogger).error(String.format(RESULT_NULL, SIZE, RETRY_COUNT));
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     public void testCountIfThrottled() {
         // Using these mocks makes the test more verbose but verifies that break; is called appropriately

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseRecordBufferCollectorTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseRecordBufferCollectorTest.java
@@ -76,11 +76,11 @@ public class FirehoseRecordBufferCollectorTest {
     }
 
     @Test
-    public void testShoudCallTheOverloadWhenCalledWithString() {
+    public void testShouldCallTheOverloadWhenCalledWithString() {
         final String data = "{\"hello\":\"world\"}";
         timesClockMillis = 2;
         firehoseCollector.addRecordAndReturnBatch(data);
-        assertEquals(1, firehoseCollector.returnIncompleteBatch().size());
+        assertEquals(1, firehoseCollector.createIncompleteBatch().size());
     }
 
     @Test
@@ -137,10 +137,10 @@ public class FirehoseRecordBufferCollectorTest {
         timesClockMillis = 3;
         testShouldCreateNewBatch(MAX_RECORDS_IN_BATCH / 2, false);
 
-        final List<Record> batch = firehoseCollector.returnIncompleteBatch();
+        final List<Record> batch = firehoseCollector.createIncompleteBatch();
 
         assertEquals(MAX_RECORDS_IN_BATCH / 2, batch.size());
-        assertEquals(0, firehoseCollector.returnIncompleteBatch().size());
+        assertEquals(0, firehoseCollector.createIncompleteBatch().size());
     }
 
     @Test

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseStringBufferCollectorTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseStringBufferCollectorTest.java
@@ -196,7 +196,7 @@ public class FirehoseStringBufferCollectorTest {
         firehoseStringBufferCollector.addToRecordBuffer(DATA_PLUS_NEWLINE);
         firehoseStringBufferCollector.addToRecordBuffer(DATA_PLUS_NEWLINE);
         assertEquals(26, firehoseStringBufferCollector.getTotalBatchSize());
-        final List<Record> batch = firehoseStringBufferCollector.returnIncompleteBatch();
+        final List<Record> batch = firehoseStringBufferCollector.createIncompleteBatch();
         final Record actual = batch.get(0);
         assertEquals(DATA_PLUS_NEWLINE + DATA_PLUS_NEWLINE, new String(actual.getData().array()));
     }
@@ -209,7 +209,7 @@ public class FirehoseStringBufferCollectorTest {
         firehoseStringBufferCollector.addRecordAndReturnBatch(DATA_PLUS_NEWLINE);
         firehoseStringBufferCollector.addRecordAndReturnBatch(DATA_PLUS_NEWLINE);
         assertEquals(52, firehoseStringBufferCollector.getTotalBatchSize());
-        final List<Record> batch = firehoseStringBufferCollector.returnIncompleteBatch();
+        final List<Record> batch = firehoseStringBufferCollector.createIncompleteBatch();
         final String expected = DATA_PLUS_NEWLINE + DATA_PLUS_NEWLINE;
         assertEquals(expected, new String(batch.get(0).getData().array()));
         assertEquals(expected, new String(batch.get(1).getData().array()));


### PR DESCRIPTION
into what might be going on. Also separate the "batch full" vs.
"timed out" decision so that the latter can add the buffered data
before sending to AWS.