### PR TITLE
Stop using BucketTimer; the template to transform Graphite plain text

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfig.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfig.java
@@ -54,9 +54,6 @@ import static com.expedia.www.haystack.pipes.firehoseWriter.Constants.APPLICATIO
 @Configuration
 @ComponentScan(basePackageClasses = SpringConfig.class)
 class SpringConfig {
-    @VisibleForTesting
-    static final long[] BUCKETS_FOR_PUT_BATCH_REQUEST_TIMER = {1L, 2L, 5L, 10L, 20L, 50L, 100L, 200L, 500L,
-            1_000L, 2_000L, 5_000L, 10_000L, 20_000L, 50_000L, 100_000L, 200_000L, 500_000L};
     private final MetricObjects metricObjects;
 
     /**
@@ -101,8 +98,8 @@ class SpringConfig {
 
     @Bean
     Timer putBatchRequestTimer() {
-        return metricObjects.createAndRegisterBucketTimer(SUBSYSTEM, APPLICATION, "PUT_BATCH_REQUEST",
-                TimeUnit.MILLISECONDS, BUCKETS_FOR_PUT_BATCH_REQUEST_TIMER);
+        return metricObjects.createAndRegisterBasicTimer(SUBSYSTEM, APPLICATION, FirehoseProcessor.class.getName(),
+                "PUT_BATCH_REQUEST", TimeUnit.MILLISECONDS);
     }
 
     @Bean

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 
 import static com.expedia.www.haystack.pipes.commons.CommonConstants.SUBSYSTEM;
 import static com.expedia.www.haystack.pipes.firehoseWriter.Constants.APPLICATION;
-import static com.expedia.www.haystack.pipes.firehoseWriter.SpringConfig.BUCKETS_FOR_PUT_BATCH_REQUEST_TIMER;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -44,7 +43,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -135,13 +133,13 @@ public class SpringConfigTest {
 
     @Test
     public void testPutBatchRequestTimer() {
-        when(mockMetricObjects.createAndRegisterBucketTimer(anyString(), anyString(), anyString(), any(TimeUnit.class),
-                anyVararg())).thenReturn(mockTimer);
+        when(mockMetricObjects.createAndRegisterBasicTimer(anyString(), anyString(), anyString(),
+                anyString(), any(TimeUnit.class))).thenReturn(mockTimer);
 
         assertNotNull(springConfig.putBatchRequestTimer());
 
-        verify(mockMetricObjects).createAndRegisterBucketTimer(SUBSYSTEM, APPLICATION, "PUT_BATCH_REQUEST",
-                MILLISECONDS, BUCKETS_FOR_PUT_BATCH_REQUEST_TIMER);
+        verify(mockMetricObjects).createAndRegisterBasicTimer(SUBSYSTEM, APPLICATION, FirehoseProcessor.class.getName(),
+                "PUT_BATCH_REQUEST", MILLISECONDS);
     }
 
     @Test


### PR DESCRIPTION
messages into tagged metrics for ingestion by InfluxDb isn't working yet
and changing it is difficult, so for now I'm reverting to BasicTimer.