### PR TITLE
Make PutRecordBatchAsync calls, with a thread pool to handle responses,

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/AsynchronousFirehoseConsumer.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/AsynchronousFirehoseConsumer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AsynchronousFirehoseConsumer {
+    private final TaskExecutor taskExecutor;
+    private final ApplicationContext applicationContext;
+
+    public AsynchronousFirehoseConsumer(TaskExecutor taskExecutor, ApplicationContext applicationContext) {
+        this.taskExecutor = taskExecutor;
+        this.applicationContext = applicationContext;
+    }
+
+    void executeAsynchronously() {
+        final FirehoseConsumer firehoseConsumer = applicationContext.getBean(FirehoseConsumer.class);
+        taskExecutor.execute(firehoseConsumer);
+    }
+}

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/BlockingQueueEntry.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/BlockingQueueEntry.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import com.netflix.servo.monitor.Stopwatch;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+class BlockingQueueEntry {
+    private final Stopwatch stopwatch;
+    private final RetryCalculator retryCalculator;
+    private final PutRecordBatchRequest putRecordBatchRequest;
+    private final Batch batch;
+    private final Future<PutRecordBatchResult> futurePutRecordBatchResult;
+
+    BlockingQueueEntry(Stopwatch stopwatch,
+                       RetryCalculator retryCalculator,
+                       PutRecordBatchRequest putRecordBatchRequest,
+                       Batch batch,
+                       Future<PutRecordBatchResult> futurePutRecordBatchResult) {
+        this.stopwatch = stopwatch;
+        this.retryCalculator = retryCalculator;
+        this.putRecordBatchRequest = putRecordBatchRequest;
+        this.batch = batch;
+        this.futurePutRecordBatchResult = futurePutRecordBatchResult;
+    }
+
+    Stopwatch getStopwatch() {
+        return stopwatch;
+    }
+
+    RetryCalculator getRetryCalculator() {
+        return retryCalculator;
+    }
+
+    PutRecordBatchRequest getPutRecordBatchRequest() {
+        return putRecordBatchRequest;
+    }
+
+    Batch getBatch() {
+        return batch;
+    }
+
+    Future<PutRecordBatchResult> getFuturePutRecordBatchResult() {
+        return futurePutRecordBatchResult;
+    }
+
+    /**
+     * Extracts failed records from a putRecordBatch attempt. This method requires to putRecordBatchResult as an
+     * argument; this argument should always be exactly the object obtained by calling get() on the
+     * futurePutRecordBatchResult instance variable; requiring it as an argument avoids having to deal with the
+     * exceptions that get() can throw, and clearly there can be no attempt to extract failed records if the result
+     * of the call has not yet been received. Typically the result will contain information about which records need
+     * to be retried, but if a null is passed to this method, all records in the request will be returned for retry.
+     *
+     * @param putRecordBatchResult the result of the AWS call
+     * @return the records that should be retried
+     */
+    List<Record> extractFailedRecords(PutRecordBatchResult putRecordBatchResult) {
+        final List<Record> records;
+        if (putRecordBatchResult != null) {
+            records = batch.extractFailedRecords(putRecordBatchRequest,
+                    putRecordBatchResult, retryCalculator.getUnboundedTryCount());
+        } else {
+            records = putRecordBatchRequest.getRecords();
+        }
+        return records;
+    }
+
+}

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/Factory.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/Factory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import com.netflix.servo.monitor.Stopwatch;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+class Factory {
+    static class SleeperImpl implements FirehoseProcessor.Sleeper {
+        @Override
+        public void sleep(long millis) throws InterruptedException {
+            Thread.sleep(millis);
+        }
+    }
+
+    PutRecordBatchRequest createPutRecordBatchRequest(String streamName, List<Record> records) {
+        final PutRecordBatchRequest putRecordBatchRequest = new PutRecordBatchRequest();
+        putRecordBatchRequest.setDeliveryStreamName(streamName);
+        putRecordBatchRequest.setRecords(records);
+        return putRecordBatchRequest;
+    }
+
+    FirehoseProcessor.Sleeper createSleeper() {
+        return new SleeperImpl();
+    }
+
+    Runtime getRuntime() {
+        return Runtime.getRuntime();
+    }
+
+    Thread createShutdownHook(FirehoseProcessor firehoseProcessor) {
+        return new Thread(new ShutdownHook(firehoseProcessor));
+    }
+
+    Thread currentThread() {
+        return Thread.currentThread();
+    }
+
+    RetryCalculator createRetryCalculator(int initialRetrySleep, int maxRetrySleep) {
+        return new RetryCalculator(initialRetrySleep, maxRetrySleep);
+    }
+
+    BlockingQueueEntry createBlockingQueueEntry(Stopwatch stopwatch,
+                                                RetryCalculator retryCalculator,
+                                                PutRecordBatchRequest putRecordBatchRequest,
+                                                Batch batch,
+                                                Future<PutRecordBatchResult> futurePutRecordBatchResult) {
+        return new BlockingQueueEntry(
+                stopwatch, retryCalculator, putRecordBatchRequest, batch, futurePutRecordBatchResult);
+    }
+}

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseConsumer.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseConsumer.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import com.netflix.servo.util.VisibleForTesting;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
+
+@Component
+public class FirehoseConsumer implements Runnable {
+    @VisibleForTesting
+    static final String EXECUTION_EXCEPTION_ERROR_MSG = "putRecordBatch() saw an ExceptionException, but will continue trying...";
+    @VisibleForTesting
+    static final String PUT_RECORD_BATCH_ERROR_MSG = "putRecordBatch() could not put %d records after %d tries, but will continue trying...";
+    @VisibleForTesting
+    static final String STARTUP_MSG = "Starting FirehoseConsumer thread";
+
+    @VisibleForTesting
+    final S3Sender s3Sender;
+    @VisibleForTesting
+    final Logger logger;
+    @VisibleForTesting
+    final FirehoseCountersAndTimer firehoseCountersAndTimer;
+    @VisibleForTesting
+    final ArrayBlockingQueue<BlockingQueueEntry> arrayBlockingQueue;
+
+    @Autowired
+    public FirehoseConsumer(S3Sender s3Sender,
+                            Logger firehoseConsumerLogger,
+                            FirehoseCountersAndTimer firehoseCountersAndTimer,
+                            ArrayBlockingQueue<BlockingQueueEntry> arrayBlockingQueue) {
+        this.s3Sender = s3Sender;
+        this.logger = firehoseConsumerLogger;
+        this.firehoseCountersAndTimer = firehoseCountersAndTimer;
+        this.arrayBlockingQueue = arrayBlockingQueue;
+    }
+
+    @Override
+    public void run() {
+        logger.info(STARTUP_MSG);
+        PutRecordBatchResult putRecordBatchResult;
+        BlockingQueueEntry blockingQueueEntry;
+        boolean isRunning = true;
+        while (isRunning) {
+            putRecordBatchResult = null;
+            blockingQueueEntry = null;
+            try {
+                blockingQueueEntry = arrayBlockingQueue.take();
+                putRecordBatchResult = blockingQueueEntry.getFuturePutRecordBatchResult().get();
+            } catch (InterruptedException e) { // take()/get(): blockingQueueEntry ?= null, putRecordBatchResult == null
+                isRunning = false;
+            } catch (ExecutionException e) {   // get()       : blockingQueueEntry != null, putRecordBatchResult == null
+                firehoseCountersAndTimer.incrementExceptionCounter();
+                logger.error(EXECUTION_EXCEPTION_ERROR_MSG, e);
+            } finally {
+                if (blockingQueueEntry != null) {
+                    blockingQueueEntry.getStopwatch().stop();
+                    final PutRecordBatchRequest putRecordBatchRequest = blockingQueueEntry.getPutRecordBatchRequest();
+                    firehoseCountersAndTimer.countSuccessesAndFailures(putRecordBatchRequest, putRecordBatchResult);
+                    final List<Record> failedRecords = blockingQueueEntry.extractFailedRecords(putRecordBatchResult);
+                    if (!failedRecords.isEmpty()) {
+                        final RetryCalculator retryCalculator = blockingQueueEntry.getRetryCalculator();
+                        if(retryCalculator.isTryCountBeyondLimit()) {
+                            logger.error(PUT_RECORD_BATCH_ERROR_MSG,
+                                    failedRecords.size(), retryCalculator.getUnboundedTryCount());
+                        }
+                        try {
+                            s3Sender.sendRecordsToS3(failedRecords, retryCalculator);
+                        } catch (InterruptedException e) {
+                            isRunning = false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCountersAndTimer.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCountersAndTimer.java
@@ -43,13 +43,13 @@ class FirehoseCountersAndTimer extends CountersAndTimer {
         super(clock, putBatchRequestTimer, spanArrivalTimer, spanCounter, successCounter, failureCounter, exceptionCounter);
     }
 
-    int countSuccessesAndFailures(PutRecordBatchRequest request, PutRecordBatchResult result) {
-        final int recordCount = request.getRecords().size();
-        final int failureCount = result == null ? recordCount : result.getFailedPutCount();
+    void countSuccessesAndFailures(PutRecordBatchRequest putRecordBatchRequest,
+                                   PutRecordBatchResult putRecordBatchResult) {
+        final int recordCount = putRecordBatchRequest.getRecords().size();
+        final int failureCount = putRecordBatchResult == null ? recordCount : putRecordBatchResult.getFailedPutCount();
         final int successCount = recordCount - failureCount;
         incrementCounter(SUCCESS_COUNTER_INDEX, successCount);
         incrementCounter(FAILURE_COUNTER_INDEX, failureCount);
-        return failureCount;
     }
 
     void incrementExceptionCounter() {

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseIsActiveController.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseIsActiveController.java
@@ -42,19 +42,23 @@ public class FirehoseIsActiveController extends SpringBootServletInitializer {
     private final ProtobufToFirehoseProducer protobufToFirehoseProducer;
     private final Factory firehoseIsActiveControllerFactory;
     private final Logger logger;
+    private final AsynchronousFirehoseConsumer asynchronousFirehoseConsumer;
 
     @Autowired
     FirehoseIsActiveController(ProtobufToFirehoseProducer protobufToFirehoseProducer,
                                Factory firehoseIsActiveControllerFactory,
-                               Logger firehoseIsActiveControllerLogger) {
+                               Logger firehoseIsActiveControllerLogger,
+                               AsynchronousFirehoseConsumer asynchronousFirehoseConsumer) {
         this.protobufToFirehoseProducer = protobufToFirehoseProducer;
         this.firehoseIsActiveControllerFactory = firehoseIsActiveControllerFactory;
         this.logger = firehoseIsActiveControllerLogger;
+        this.asynchronousFirehoseConsumer = asynchronousFirehoseConsumer;
         INSTANCE.compareAndSet(null, this);
     }
 
     public static void main(String[] args) {
         new AnnotationConfigApplicationContext(SpringConfig.class);
+        INSTANCE.get().asynchronousFirehoseConsumer.executeAsynchronously();
         INSTANCE.get().logger.info(STARTUP_MSG);
         INSTANCE.get().protobufToFirehoseProducer.main();
         INSTANCE.get().firehoseIsActiveControllerFactory.createSpringApplication().run(args);

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessor.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessor.java
@@ -16,12 +16,8 @@
  */
 package com.expedia.www.haystack.pipes.firehoseWriter;
 
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
 import com.amazonaws.services.kinesisfirehose.model.Record;
 import com.expedia.open.tracing.Span;
-import com.netflix.servo.monitor.Stopwatch;
 import com.netflix.servo.util.VisibleForTesting;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -36,33 +32,26 @@ import java.util.function.Supplier;
 public class FirehoseProcessor implements Processor<String, Span> {
     @VisibleForTesting
     static final String STARTUP_MESSAGE = "Instantiating FirehoseAction into stream name [%s]";
-    @VisibleForTesting
-    static final String PUT_RECORD_BATCH_WARN_MSG = "putRecordBatch() failed; retryCount=%d";
-    @VisibleForTesting
-    static final String PUT_RECORD_BATCH_ERROR_MSG = "putRecordBatch() could not put %d records after %d tries, but will continue trying...";
 
-    private final Logger logger;
     private final FirehoseCountersAndTimer firehoseCountersAndTimer;
     private final Batch batch;
-    private final AmazonKinesisFirehoseAsync amazonKinesisFirehoseAsync;
-    private final Factory factory;
     private final FirehoseConfigurationProvider firehoseConfigurationProvider;
+    private final Factory factory;
+    private final S3Sender s3Sender;
 
     @Autowired
     FirehoseProcessor(Logger firehoseProcessorLogger,
                       FirehoseCountersAndTimer firehoseCountersAndTimer,
                       Supplier<Batch> batch,
-                      AmazonKinesisFirehoseAsync amazonKinesisFirehoseAsync,
-                      Factory firehoseProcessorFactory,
-                      FirehoseConfigurationProvider firehoseConfigurationProvider) {
-        this.logger = firehoseProcessorLogger;
+                      FirehoseConfigurationProvider firehoseConfigurationProvider,
+                      Factory factory,
+                      S3Sender s3Sender) {
+        firehoseProcessorLogger.info(String.format(STARTUP_MESSAGE, firehoseConfigurationProvider.streamname()));
         this.firehoseCountersAndTimer = firehoseCountersAndTimer;
         this.batch = batch.get();
-        this.amazonKinesisFirehoseAsync = amazonKinesisFirehoseAsync;
-        this.factory = firehoseProcessorFactory;
         this.firehoseConfigurationProvider = firehoseConfigurationProvider;
-
-        this.logger.info(String.format(STARTUP_MESSAGE, firehoseConfigurationProvider.streamname()));
+        this.factory = factory;
+        this.s3Sender = s3Sender;
     }
 
     @Override
@@ -75,95 +64,18 @@ public class FirehoseProcessor implements Processor<String, Span> {
         firehoseCountersAndTimer.incrementRequestCounter();
         firehoseCountersAndTimer.recordSpanArrivalDelta(span);
         final List<Record> records = batch.getRecordList(span);
-        sendRecordsToS3(records);
+        try {
+            final RetryCalculator retryCalculator = factory.createRetryCalculator(
+                    firehoseConfigurationProvider.initialretrysleep(), firehoseConfigurationProvider.maxretrysleep());
+            s3Sender.sendRecordsToS3(records, retryCalculator);
+        } catch (InterruptedException e) {
+            factory.currentThread().interrupt();
+        }
     }
 
     @Override
     public void close() {
-        final List<Record> records = batch.getRecordListForShutdown();
-        sendRecordsToS3(records);
-    }
-
-    private class RetryCalculator {
-        final int initialRetrySleep;
-        final int maxRetrySleep;
-        int boundedTryCount; // never increments more than one step past the value that causes the exponential backoff
-                             // time calculation to exceed maxRetrySleep; this avoids problems for > 31 tries.
-        private RetryCalculator(int initialRetrySleep, int maxRetrySleep) {
-            this.initialRetrySleep = initialRetrySleep;
-            this.maxRetrySleep = maxRetrySleep;
-        }
-
-        /**
-         * Calculates the number of milliseconds to sleep. The first time this method is called, it returns 0.
-         * The second time it returns 1 * initialRetrySleep, the third time it returns 2 * initialRetrySleep,
-         * the fourth time it returns 4 * initialRetrySleep, the fifth time it returns 8 * initialRetrySleep, etc.
-         * But the returned value is bounded by maxRetrySleep; it will never return a number larger than maxRetrySleep.
-         * @return milliseconds to sleep
-         */
-        private int calculateSleepMillis() {
-            final int sleepMillisPerTryCount = (1 << (boundedTryCount - 1)) * initialRetrySleep;
-            final int sleepMillis;
-            if(sleepMillisPerTryCount > maxRetrySleep) {
-                sleepMillis = maxRetrySleep;
-            } else {
-                sleepMillis = sleepMillisPerTryCount;
-                ++boundedTryCount;
-            }
-            return Math.min(sleepMillis, maxRetrySleep);
-        }
-    }
-
-    private void sendRecordsToS3(List<Record> records) {
-        int retryCount = 0;
-        int failureCount;
-        if (!records.isEmpty()) {
-            final String streamName = firehoseConfigurationProvider.streamname();
-            final int maxRetrySleep = firehoseConfigurationProvider.maxretrysleep();
-            final RetryCalculator retryCalculator = new RetryCalculator(
-                    firehoseConfigurationProvider.initialretrysleep(), maxRetrySleep);
-            final Sleeper sleeper = factory.createSleeper();
-
-            boolean allRecordsPutSuccessfully = false;
-            do {
-                final PutRecordBatchRequest request = factory.createPutRecordBatchRequest(streamName, records);
-                final Stopwatch stopwatch = firehoseCountersAndTimer.startTimer();
-                final int sleepMillis = retryCalculator.calculateSleepMillis();
-                PutRecordBatchResult result = null;
-                try {
-                    sleeper.sleep(sleepMillis);
-                    result = amazonKinesisFirehoseAsync.putRecordBatch(request);
-                } catch (Exception exception) {
-                    firehoseCountersAndTimer.incrementExceptionCounter();
-                    logger.error(String.format(PUT_RECORD_BATCH_WARN_MSG, retryCount++), exception);
-                    continue;
-                } finally {
-                    stopwatch.stop();
-                    failureCount = firehoseCountersAndTimer.countSuccessesAndFailures(request, result);
-                }
-                if (result == null || areThereRecordsThatFirehoseHasNotProcessed(result.getFailedPutCount())) {
-                    records = batch.extractFailedRecords(request, result, retryCount++);
-                } else {
-                    allRecordsPutSuccessfully = true;
-                }
-                if (shouldLogErrorMessage(failureCount, maxRetrySleep, sleepMillis)) {
-                    logger.error(String.format(PUT_RECORD_BATCH_ERROR_MSG, failureCount, retryCount));
-                }
-            } while (!allRecordsPutSuccessfully);
-        }
-    }
-
-    private boolean shouldLogErrorMessage(int failureCount, int maxRetrySleep, int sleepMillis) {
-        return hasSleepMillisReachedItsLimit(maxRetrySleep, sleepMillis)
-                && (areThereRecordsThatFirehoseHasNotProcessed(failureCount));
-    }
-
-    private boolean hasSleepMillisReachedItsLimit(int maxRetrySleep, int sleepMillis) {
-        return sleepMillis == maxRetrySleep;
-    }
-
-    private boolean areThereRecordsThatFirehoseHasNotProcessed(int failureCount) {
-        return failureCount > 0;
+        s3Sender.close();
     }
 
     @Override
@@ -179,44 +91,4 @@ public class FirehoseProcessor implements Processor<String, Span> {
         void sleep(long millis) throws InterruptedException;
     }
 
-    static class Factory {
-        class SleeperImpl implements Sleeper {
-            @Override
-            public void sleep(long millis) throws InterruptedException {
-                Thread.sleep(millis);
-            }
-        }
-
-        PutRecordBatchRequest createPutRecordBatchRequest(String streamName, List<Record> records) {
-            final PutRecordBatchRequest putRecordBatchRequest = new PutRecordBatchRequest();
-            putRecordBatchRequest.setDeliveryStreamName(streamName);
-            putRecordBatchRequest.setRecords(records);
-            return putRecordBatchRequest;
-        }
-
-        Sleeper createSleeper() {
-            return new SleeperImpl();
-        }
-
-        Runtime getRuntime() {
-            return Runtime.getRuntime();
-        }
-
-        Thread createShutdownHook(FirehoseProcessor firehoseProcessor) {
-            return new Thread(new ShutdownHook(firehoseProcessor));
-        }
-    }
-
-    static class ShutdownHook implements Runnable {
-        private final FirehoseProcessor firehoseProcessor;
-
-        ShutdownHook(FirehoseProcessor firehoseProcessor) {
-            this.firehoseProcessor = firehoseProcessor;
-        }
-
-        @Override
-        public void run() {
-            firehoseProcessor.close();
-        }
-    }
 }

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplier.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplier.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.firehoseWriter;
 
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
 import com.expedia.open.tracing.Span;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
@@ -15,28 +30,28 @@ public class FirehoseProcessorSupplier implements ProcessorSupplier<String, Span
     private final Logger firehoseProcessorLogger;
     private final FirehoseCountersAndTimer firehoseCountersAndTimer;
     private final Supplier<Batch> batch;
-    private final AmazonKinesisFirehoseAsync amazonKinesisFirehoseAsync;
-    private final FirehoseProcessor.Factory firehoseProcessorFactory;
+    private final Factory firehoseProcessorFactory;
     private final FirehoseConfigurationProvider firehoseConfigurationProvider;
+    private final S3Sender s3Sender;
 
     @Autowired
     public FirehoseProcessorSupplier(Logger firehoseProcessorLogger,
                                      FirehoseCountersAndTimer firehoseCountersAndTimer,
                                      Supplier<Batch> batch,
-                                     AmazonKinesisFirehoseAsync amazonKinesisFirehoseAsync,
-                                     FirehoseProcessor.Factory firehoseProcessorFactory,
-                                     FirehoseConfigurationProvider firehoseConfigurationProvider) {
+                                     Factory firehoseProcessorFactory,
+                                     FirehoseConfigurationProvider firehoseConfigurationProvider,
+                                     S3Sender s3Sender) {
         this.firehoseProcessorLogger = firehoseProcessorLogger;
         this.firehoseCountersAndTimer = firehoseCountersAndTimer;
         this.batch = batch;
-        this.amazonKinesisFirehoseAsync = amazonKinesisFirehoseAsync;
         this.firehoseProcessorFactory = firehoseProcessorFactory;
         this.firehoseConfigurationProvider = firehoseConfigurationProvider;
+        this.s3Sender = s3Sender;
     }
 
     @Override
     public Processor<String, Span> get() {
         return new FirehoseProcessor(firehoseProcessorLogger, firehoseCountersAndTimer, batch,
-                amazonKinesisFirehoseAsync, firehoseProcessorFactory, firehoseConfigurationProvider);
+                firehoseConfigurationProvider, firehoseProcessorFactory, s3Sender);
     }
 }

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/RetryCalculator.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/RetryCalculator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+class RetryCalculator {
+    final int initialRetrySleep;
+    final int maxRetrySleep;
+    private int boundedTryCount; // never increments more than one step past the value that causes the exponential backoff
+                                 // time calculation to exceed maxRetrySleep; this avoids problems with the use of <<
+                                 // during the power-of-2 exponential retry calculation for > 31 tries
+    private int unboundedTryCount;
+
+    RetryCalculator(int initialRetrySleep, int maxRetrySleep) {
+        this.initialRetrySleep = initialRetrySleep;
+        this.maxRetrySleep = maxRetrySleep;
+    }
+
+    /**
+     * Calculates the number of milliseconds to sleep. The first time this method is called, it returns 0, so that
+     * it can be called (with minimal performance impact) before the first try. The second time it returns
+     * 1 * initialRetrySleep, the third time it returns 2 * initialRetrySleep, the fourth time it returns
+     * 4 * initialRetrySleep, the fifth time it returns 8 * initialRetrySleep, etc. The returned value is bounded by
+     * maxRetrySleep; this method will never return a number larger than maxRetrySleep.
+     *
+     * @return milliseconds to sleep
+     */
+    int calculateSleepMillis() {
+        final int sleepMillisPerTryCount = (1 << (boundedTryCount - 1)) * initialRetrySleep;
+        final int sleepMillis;
+        if (sleepMillisPerTryCount > maxRetrySleep) {
+            sleepMillis = maxRetrySleep;
+        } else {
+            sleepMillis = sleepMillisPerTryCount;
+            ++boundedTryCount;
+        }
+        ++unboundedTryCount;
+        return Math.min(sleepMillis, maxRetrySleep);
+    }
+
+    boolean isTryCountBeyondLimit() {
+        return unboundedTryCount > boundedTryCount;
+    }
+
+    int getUnboundedTryCount() {
+        return unboundedTryCount;
+    }
+}

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/S3Sender.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/S3Sender.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import com.expedia.www.haystack.pipes.firehoseWriter.FirehoseProcessor.Sleeper;
+import com.netflix.servo.monitor.Stopwatch;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+@Component
+public class S3Sender {
+    private final Sleeper sleeper;
+    private final Factory factory;
+    private final FirehoseConfigurationProvider firehoseConfigurationProvider;
+    private final String streamName;
+    private final FirehoseCountersAndTimer firehoseCountersAndTimer;
+    private final AmazonKinesisFirehoseAsync amazonKinesisFirehoseAsync;
+    private final Batch batch;
+    private final ArrayBlockingQueue<BlockingQueueEntry> arrayBlockingQueue;
+
+    @Autowired
+    public S3Sender(Supplier<Batch> batchSupplier,
+                    Sleeper sleeper,
+                    Factory firehoseProcessorFactory,
+                    FirehoseConfigurationProvider firehoseConfigurationProvider,
+                    FirehoseCountersAndTimer firehoseCountersAndTimer,
+                    AmazonKinesisFirehoseAsync amazonKinesisFirehoseAsync,
+                    ArrayBlockingQueue<BlockingQueueEntry> arrayBlockingQueue) {
+        this.batch = batchSupplier.get();
+        this.sleeper = sleeper;
+        this.factory = firehoseProcessorFactory;
+        this.firehoseConfigurationProvider = firehoseConfigurationProvider;
+        this.streamName = firehoseConfigurationProvider.streamname();
+        this.firehoseCountersAndTimer = firehoseCountersAndTimer;
+        this.amazonKinesisFirehoseAsync = amazonKinesisFirehoseAsync;
+        this.arrayBlockingQueue = arrayBlockingQueue;
+    }
+
+    /**
+     * Sends records to S3
+     * @param recordList records to send
+     * @param retryCalculator RetryCalculator to use; pass in a new RetryCalculator for the first putRecordBatchRequest, but for
+     *                        retries send in the RetryCalculator used for the initial try
+     */
+    void sendRecordsToS3(List<Record> recordList, RetryCalculator retryCalculator) throws InterruptedException {
+        if (!recordList.isEmpty()) {
+            sleeper.sleep(retryCalculator.calculateSleepMillis());
+            final PutRecordBatchRequest putRecordBatchRequest =
+                    factory.createPutRecordBatchRequest(streamName, recordList);
+            final Stopwatch stopwatch = firehoseCountersAndTimer.startTimer();
+            final Future<PutRecordBatchResult> recordBatchResultFuture =
+                    amazonKinesisFirehoseAsync.putRecordBatchAsync(putRecordBatchRequest);
+            final BlockingQueueEntry blockingQueueEntry = factory.createBlockingQueueEntry(
+                    stopwatch, retryCalculator, putRecordBatchRequest, batch, recordBatchResultFuture);
+            arrayBlockingQueue.put(blockingQueueEntry);
+        }
+    }
+
+    void close() {
+        final List<Record> recordList = batch.getRecordListForShutdown();
+        try {
+            final RetryCalculator retryCalculator = factory.createRetryCalculator(
+                    firehoseConfigurationProvider.initialretrysleep(), firehoseConfigurationProvider.maxretrysleep());
+            sendRecordsToS3(recordList, retryCalculator);
+        } catch (InterruptedException e) {
+            factory.currentThread().interrupt();
+        }
+    }
+
+}

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/ShutdownHook.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/ShutdownHook.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+class ShutdownHook implements Runnable {
+    private final FirehoseProcessor firehoseProcessor;
+
+    ShutdownHook(FirehoseProcessor firehoseProcessor) {
+        this.firehoseProcessor = firehoseProcessor;
+    }
+
+    @Override
+    public void run() {
+        firehoseProcessor.close();
+    }
+}

--- a/firehose-writer/src/main/resources/log4j2.yaml
+++ b/firehose-writer/src/main/resources/log4j2.yaml
@@ -49,6 +49,13 @@ Configuration:
       AppenderRef:
         - ref: Console
         - ref: EmitToGraphiteLog4jAppender
+    Logger:
+      name: com.expedia.www.haystack.pipes.firehoseWriter.FirehoseConsumer
+      level: info
+      additivity: false
+      AppenderRef:
+        - ref: Console
+        - ref: EmitToGraphiteLog4jAppender
     Root:
       level: error
       AppenderRef:

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/AsynchronousFirehoseConsumerTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/AsynchronousFirehoseConsumerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.task.TaskExecutor;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AsynchronousFirehoseConsumerTest {
+    @Mock
+    private TaskExecutor mockTaskExecutor;
+    @Mock
+    private ApplicationContext mockApplicationContext;
+    @Mock
+    private FirehoseConsumer mockFirehoseConsumer;
+
+    private AsynchronousFirehoseConsumer asynchronousFirehoseConsumer;
+
+    @Before
+    public void setUp() {
+        asynchronousFirehoseConsumer = new AsynchronousFirehoseConsumer(mockTaskExecutor, mockApplicationContext);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockTaskExecutor);
+        verifyNoMoreInteractions(mockApplicationContext);
+        verifyNoMoreInteractions(mockFirehoseConsumer);
+    }
+
+    @Test
+    public void testExecuteAsynchronously() {
+        when(mockApplicationContext.getBean(FirehoseConsumer.class)).thenReturn(mockFirehoseConsumer);
+
+        asynchronousFirehoseConsumer.executeAsynchronously();
+
+        verify(mockApplicationContext).getBean(FirehoseConsumer.class);
+        verify(mockTaskExecutor).execute(mockFirehoseConsumer);
+    }
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/BlockingQueueEntryTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/BlockingQueueEntryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import com.netflix.servo.monitor.Stopwatch;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BlockingQueueEntryTest {
+    private static final int UNBOUNDED_TRY_COUNT = RANDOM.nextInt(Byte.MAX_VALUE);
+    @Mock
+    private Stopwatch mockStopwatch;
+
+    @Mock
+    private RetryCalculator mockRetryCalculator;
+
+    @Mock
+    private PutRecordBatchRequest mockPutRecordBatchRequest;
+
+    @Mock
+    private Batch mockBatch;
+
+    @Mock
+    private Future<PutRecordBatchResult> mockFuture;
+
+    @Mock
+    private Record mockRecord;
+
+    @Mock
+    private PutRecordBatchResult mockRPutRecordBatchResult;
+
+    private BlockingQueueEntry blockingQueueEntry;
+    private List<Record> recordList;
+
+    @Before
+    public void setUp() {
+        blockingQueueEntry = new BlockingQueueEntry(
+                mockStopwatch, mockRetryCalculator, mockPutRecordBatchRequest, mockBatch, mockFuture);
+        recordList = Collections.singletonList(mockRecord);
+    }
+
+    @SuppressWarnings("Duplicates")
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockStopwatch);
+        verifyNoMoreInteractions(mockRetryCalculator);
+        verifyNoMoreInteractions(mockPutRecordBatchRequest);
+        verifyNoMoreInteractions(mockBatch);
+        verifyNoMoreInteractions(mockFuture);
+        verifyNoMoreInteractions(mockRecord);
+        verifyNoMoreInteractions(mockRPutRecordBatchResult);
+    }
+
+    @Test
+    public void testConstructor() {
+        assertSame(mockStopwatch, blockingQueueEntry.getStopwatch());
+        assertSame(mockRetryCalculator, blockingQueueEntry.getRetryCalculator());
+        assertSame(mockPutRecordBatchRequest, blockingQueueEntry.getPutRecordBatchRequest());
+        assertSame(mockBatch, blockingQueueEntry.getBatch());
+        assertSame(mockFuture, blockingQueueEntry.getFuturePutRecordBatchResult());
+    }
+
+    @Test
+    public void testExtractFailedRecordsNullResult() {
+        when(mockPutRecordBatchRequest.getRecords()).thenReturn(recordList);
+
+        assertEquals(recordList, blockingQueueEntry.extractFailedRecords(null));
+
+        verify(mockPutRecordBatchRequest).getRecords();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void testExtractFailedRecordsNonNullResult() {
+        when(mockRetryCalculator.getUnboundedTryCount()).thenReturn(UNBOUNDED_TRY_COUNT);
+        when(mockBatch.extractFailedRecords(
+                any(PutRecordBatchRequest.class), any(PutRecordBatchResult.class), anyInt()))
+                .thenReturn(recordList);
+
+        assertEquals(recordList, blockingQueueEntry.extractFailedRecords(mockRPutRecordBatchResult));
+
+        verify(mockRetryCalculator).getUnboundedTryCount();
+        verify(mockBatch).extractFailedRecords(
+                mockPutRecordBatchRequest, mockRPutRecordBatchResult, UNBOUNDED_TRY_COUNT);
+    }
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FactoryTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FactoryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import com.netflix.servo.monitor.Stopwatch;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FactoryTest {
+    private static final String STREAM_NAME = RANDOM.nextLong() + "STREAM_NAME";
+    private static final int INITIAL_RETRY_SLEEP = RANDOM.nextInt();
+    private static final int MAX_RETRY_SLEEP = RANDOM.nextInt();
+
+    @Mock
+    private FirehoseProcessor mockFirehoseProcessor;
+    @Mock
+    private Stopwatch mockStopwatch;
+    @Mock
+    private RetryCalculator mockRetryCalculator;
+    @Mock
+    private PutRecordBatchRequest mockPutRecordBatchRequest;
+    @Mock
+    private Batch mockBatch;
+    @Mock
+    private Future<PutRecordBatchResult> mockPutRecordBatchResultFuture;
+
+    private Factory factory;
+
+    @Before
+    public void setUp() {
+        factory = new Factory();
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockFirehoseProcessor);
+        verifyNoMoreInteractions(mockStopwatch);
+        verifyNoMoreInteractions(mockRetryCalculator);
+        verifyNoMoreInteractions(mockPutRecordBatchRequest);
+        verifyNoMoreInteractions(mockBatch);
+        verifyNoMoreInteractions(mockPutRecordBatchResultFuture);
+    }
+
+    @Test
+    public void testFactoryCreatePutRecordBatchRequest() {
+        final List<Record> records = Collections.emptyList();
+        final PutRecordBatchRequest request = factory.createPutRecordBatchRequest(STREAM_NAME, records);
+
+        assertEquals(STREAM_NAME, request.getDeliveryStreamName());
+        assertEquals(records, request.getRecords());
+    }
+
+    @Test
+    public void testFactoryGetRuntime() {
+        assertSame(Runtime.getRuntime(), factory.getRuntime());
+    }
+
+    @Test
+    public void testFactoryCreateShutdownHookAndShutdownHookClass() {
+        factory.createShutdownHook(mockFirehoseProcessor).run();
+
+        verify(mockFirehoseProcessor).close();
+    }
+
+    @Test
+    public void testCurrentThread() {
+        assertSame(Thread.currentThread(), factory.currentThread());
+    }
+
+    @Test
+    public void testCreateRetryCalculator() {
+        final RetryCalculator retryCalculator = factory.createRetryCalculator(INITIAL_RETRY_SLEEP, MAX_RETRY_SLEEP);
+
+        assertEquals(INITIAL_RETRY_SLEEP, retryCalculator.initialRetrySleep);
+        assertEquals(MAX_RETRY_SLEEP, retryCalculator.maxRetrySleep);
+    }
+
+    @Test
+    public void testCreateBlockingQueueEntry() {
+        final BlockingQueueEntry blockingQueueEntry = factory.createBlockingQueueEntry(mockStopwatch,
+                mockRetryCalculator, mockPutRecordBatchRequest, mockBatch, mockPutRecordBatchResultFuture);
+
+        assertSame(mockStopwatch, blockingQueueEntry.getStopwatch());
+        assertSame(mockRetryCalculator, blockingQueueEntry.getRetryCalculator());
+        assertSame(mockPutRecordBatchRequest, blockingQueueEntry.getPutRecordBatchRequest());
+        assertSame(mockBatch, blockingQueueEntry.getBatch());
+        assertSame(mockPutRecordBatchResultFuture, blockingQueueEntry.getFuturePutRecordBatchResult());
+    }
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseConsumerTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseConsumerTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import com.netflix.servo.monitor.Stopwatch;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static com.expedia.www.haystack.pipes.firehoseWriter.FirehoseConsumer.EXECUTION_EXCEPTION_ERROR_MSG;
+import static com.expedia.www.haystack.pipes.firehoseWriter.FirehoseConsumer.PUT_RECORD_BATCH_ERROR_MSG;
+import static com.expedia.www.haystack.pipes.firehoseWriter.FirehoseConsumer.STARTUP_MSG;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+@RunWith(MockitoJUnitRunner.class)
+public class FirehoseConsumerTest {
+    private static final int UNBOUNDED_TRY_COUNT = RANDOM.nextInt(Byte.MAX_VALUE);
+    private static final InterruptedException INTERRUPTED_EXCEPTION = new InterruptedException("Test");
+    private static final ExecutionException EXECUTION_EXCEPTION = new ExecutionException(INTERRUPTED_EXCEPTION);
+
+    @Mock
+    private S3Sender mockS3Sender;
+    @Mock
+    private Logger mockLogger;
+    @Mock
+    private FirehoseCountersAndTimer mockFirehoseCountersAndTimer;
+    @Mock
+    private ArrayBlockingQueue<BlockingQueueEntry> mockArrayBlockingQueue;
+    @Mock
+    private Future<PutRecordBatchResult> mockFuturePutRecordBatchResult;
+    @Mock
+    private PutRecordBatchResult mockPutRecordBatchResult;
+    @Mock
+    private BlockingQueueEntry mockBlockingQueueEntry;
+    @Mock
+    private Stopwatch mockStopwatch;
+    @Mock
+    private PutRecordBatchRequest mockPutRecordBatchRequest;
+    @Mock
+    private RetryCalculator mockRetryCalculator;
+    @Mock
+    private Record mockRecord;
+
+    private FirehoseConsumer firehoseConsumer;
+
+    @Before
+    public void setUp() {
+        firehoseConsumer = new FirehoseConsumer(
+                mockS3Sender, mockLogger, mockFirehoseCountersAndTimer, mockArrayBlockingQueue);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockS3Sender);
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockFirehoseCountersAndTimer);
+        verifyNoMoreInteractions(mockArrayBlockingQueue);
+        verifyNoMoreInteractions(mockFuturePutRecordBatchResult);
+        verifyNoMoreInteractions(mockPutRecordBatchResult);
+        verifyNoMoreInteractions(mockBlockingQueueEntry);
+        verifyNoMoreInteractions(mockStopwatch);
+        verifyNoMoreInteractions(mockPutRecordBatchRequest);
+        verifyNoMoreInteractions(mockRetryCalculator);
+        verifyNoMoreInteractions(mockRecord);
+    }
+
+    @Test
+    public void testRunHappyCase() throws InterruptedException, ExecutionException {
+        whensForTestRunTake();
+        whensForTestRunGetPutRecordBatchRequest();
+        whensForTestRunGet();
+        whensForTestExtractFailedRecords(Collections.emptyList());
+
+        firehoseConsumer.run();
+
+        verifiesForTestRunTake(2);
+        verifiesForTestRunGetFuturePutRecordBatchResult(1);
+        verifiesForTestRunGetPutRecordBatchRequest(1);
+        verifiesForTestExtractFailedRecords(1);
+    }
+
+    @Test
+    public void testRunSuccessfulRetry() throws InterruptedException, ExecutionException {
+        testRunSuccessfulRetry(Collections.singletonList(mockRecord));
+    }
+
+    @Test
+    public void testRunSuccessfulRetrySendRecordsToS3InterruptedException()
+            throws InterruptedException, ExecutionException {
+        final List<Record> failedRecords = Collections.singletonList(mockRecord);
+        whensForTestRunTake(mockBlockingQueueEntry);
+        whensForTestRunGetPutRecordBatchRequest(mockFuturePutRecordBatchResult);
+        whensForTestRunGet(mockPutRecordBatchResult);
+        whensForTestExtractFailedRecords(failedRecords);
+        doThrow(INTERRUPTED_EXCEPTION).when(mockS3Sender)
+                .sendRecordsToS3(anyListOf(Record.class), any(RetryCalculator.class));
+
+        firehoseConsumer.run();
+
+        verifiesForTestRunTake(1);
+        verifiesForTestRunGetFuturePutRecordBatchResult(1);
+        verifiesForTestRunGetPutRecordBatchRequest(1);
+        verifiesForTestExtractFailedRecords(1);
+        verifiesForTestRunSendRecordsToS3(failedRecords);
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void testRunSuccessfulRetryTryCountBeyondLimit() throws InterruptedException, ExecutionException {
+        when(mockRetryCalculator.getUnboundedTryCount()).thenReturn(UNBOUNDED_TRY_COUNT);
+        when(mockRetryCalculator.isTryCountBeyondLimit()).thenReturn(true);
+        testRunSuccessfulRetry(Collections.singletonList(mockRecord));
+        verify(mockRetryCalculator).getUnboundedTryCount();
+        verify(mockLogger).error(PUT_RECORD_BATCH_ERROR_MSG, 1, UNBOUNDED_TRY_COUNT);
+    }
+
+    private void testRunSuccessfulRetry(List<Record> failedRecords) throws InterruptedException, ExecutionException {
+        whensForTestRunTake(mockBlockingQueueEntry);
+        whensForTestRunGetPutRecordBatchRequest(mockFuturePutRecordBatchResult);
+        whensForTestRunGet(mockPutRecordBatchResult);
+        whensForTestExtractFailedRecords(failedRecords);
+
+        firehoseConsumer.run();
+
+        verifiesForTestRunTake(3);
+        verifiesForTestRunGetFuturePutRecordBatchResult(2);
+        verifiesForTestRunGetPutRecordBatchRequest(2);
+        verifiesForTestExtractFailedRecords(2);
+        verifiesForTestRunSendRecordsToS3(failedRecords);
+    }
+
+    @Test
+    public void testRunExecutionException() throws InterruptedException, ExecutionException {
+        final List<Record> failedRecords = Collections.singletonList(mockRecord);
+        whensForTestRunTake(mockBlockingQueueEntry);
+        whensForTestRunGetPutRecordBatchRequest(mockFuturePutRecordBatchResult);
+        whensForTestRunGet();
+        whensForTestExtractFailedRecords(failedRecords);
+
+        firehoseConsumer.run();
+
+        verifiesForTestRunTake(3);
+        verifiesForTestRunGetFuturePutRecordBatchResult(2);
+        verifiesForTestRunGetPutRecordBatchRequest(2);
+        verifiesForTestExtractFailedRecords(1);
+        verifiesForTestRunSendRecordsToS3(failedRecords);
+        verify(mockLogger).error(EXECUTION_EXCEPTION_ERROR_MSG, EXECUTION_EXCEPTION);
+        verify(mockFirehoseCountersAndTimer).incrementExceptionCounter();
+        verify(mockFirehoseCountersAndTimer).countSuccessesAndFailures(mockPutRecordBatchRequest, null);
+        verify(mockBlockingQueueEntry).extractFailedRecords(null);
+    }
+
+    private void whensForTestRunTake(BlockingQueueEntry... blockingQueueEntries) throws InterruptedException {
+        when(mockArrayBlockingQueue.take())
+                .thenReturn(mockBlockingQueueEntry, blockingQueueEntries)
+                .thenThrow(INTERRUPTED_EXCEPTION);
+    }
+
+    private void whensForTestRunGetPutRecordBatchRequest(Future<PutRecordBatchResult>... futurePutRecordBatchRequests) {
+        when(mockBlockingQueueEntry.getFuturePutRecordBatchResult())
+                .thenReturn(mockFuturePutRecordBatchResult, futurePutRecordBatchRequests);
+    }
+
+    private void whensForTestRunGet(PutRecordBatchResult... putRecordBatchResults)
+            throws ExecutionException, InterruptedException {
+        when(mockFuturePutRecordBatchResult.get())
+                .thenReturn(mockPutRecordBatchResult, putRecordBatchResults)
+                .thenThrow(EXECUTION_EXCEPTION);
+        when(mockBlockingQueueEntry.getStopwatch()).thenReturn(mockStopwatch);
+        when(mockBlockingQueueEntry.getPutRecordBatchRequest()).thenReturn(mockPutRecordBatchRequest);
+        when(mockBlockingQueueEntry.getRetryCalculator()).thenReturn(mockRetryCalculator);
+    }
+
+    private void whensForTestExtractFailedRecords(List<Record> failedRecords) {
+        when(mockBlockingQueueEntry.extractFailedRecords(any(PutRecordBatchResult.class)))
+                .thenReturn(failedRecords)
+                .thenReturn(Collections.emptyList());
+        when(mockRetryCalculator.getUnboundedTryCount()).thenReturn(UNBOUNDED_TRY_COUNT);
+    }
+
+    private void verifiesForTestRunTake(int wantedNumberOfInvocations) throws InterruptedException {
+        verify(mockLogger).info(STARTUP_MSG);
+        verify(mockArrayBlockingQueue, times(wantedNumberOfInvocations)).take();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private void verifiesForTestRunGetFuturePutRecordBatchResult(int wantedNumberOfInvocations)
+            throws InterruptedException, ExecutionException {
+        verify(mockBlockingQueueEntry, times(wantedNumberOfInvocations)).getFuturePutRecordBatchResult();
+        verify(mockFuturePutRecordBatchResult, times(wantedNumberOfInvocations)).get();
+        verify(mockBlockingQueueEntry, times(wantedNumberOfInvocations)).getStopwatch();
+        verify(mockStopwatch, times(wantedNumberOfInvocations)).stop();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private void verifiesForTestRunGetPutRecordBatchRequest(int wantedNumberOfInvocations) {
+        verify(mockBlockingQueueEntry, times(wantedNumberOfInvocations)).getPutRecordBatchRequest();
+    }
+
+    private void verifiesForTestExtractFailedRecords(int wantedNumberOfInvocations) {
+        verify(mockFirehoseCountersAndTimer, times(wantedNumberOfInvocations)).countSuccessesAndFailures(
+                mockPutRecordBatchRequest, mockPutRecordBatchResult);
+        verify(mockBlockingQueueEntry, times(wantedNumberOfInvocations)).extractFailedRecords(mockPutRecordBatchResult);
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private void verifiesForTestRunSendRecordsToS3(List<Record> failedRecords) throws InterruptedException {
+        verify(mockBlockingQueueEntry, times(failedRecords.size())).getRetryCalculator();
+        verify(mockRetryCalculator, times(failedRecords.size())).isTryCountBeyondLimit();
+        verify(mockS3Sender).sendRecordsToS3(failedRecords, mockRetryCalculator);
+    }
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseIsActiveControllerTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseIsActiveControllerTest.java
@@ -47,6 +47,8 @@ public class FirehoseIsActiveControllerTest {
     private SpringApplication mockSpringApplication;
     @Mock
     private Logger mockLogger;
+    @Mock
+    private AsynchronousFirehoseConsumer mockAsynchronousFirehoseConsumer;
 
     private Factory factory;
 
@@ -57,12 +59,16 @@ public class FirehoseIsActiveControllerTest {
     }
 
     private void storeFirehoseIsActiveControllerWithMocksInStaticInstance() {
-        new FirehoseIsActiveController(mockProtobufToFirehoseProducer, mockFactory, mockLogger);
+        new FirehoseIsActiveController(mockProtobufToFirehoseProducer, mockFactory, mockLogger, mockAsynchronousFirehoseConsumer);
     }
 
     @After
     public void tearDown() {
-        verifyNoMoreInteractions(mockProtobufToFirehoseProducer, mockFactory, mockSpringApplication, mockLogger);
+        verifyNoMoreInteractions(mockProtobufToFirehoseProducer);
+        verifyNoMoreInteractions(mockFactory);
+        verifyNoMoreInteractions(mockSpringApplication);
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockAsynchronousFirehoseConsumer);
         clearFirehoseIsActiveControllerInStaticInstance();
     }
 
@@ -77,6 +83,7 @@ public class FirehoseIsActiveControllerTest {
         FirehoseIsActiveController.main(ARGS);
 
         verify(mockLogger).info(STARTUP_MSG);
+        verify(mockAsynchronousFirehoseConsumer).executeAsynchronously();
         verify(mockProtobufToFirehoseProducer).main();
         verify(mockFactory).createSpringApplication();
         verify(mockSpringApplication).run(ARGS);

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplierTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorSupplierTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.firehoseWriter;
 
 import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
@@ -32,23 +48,31 @@ public class FirehoseProcessorSupplierTest {
     @Mock
     private AmazonKinesisFirehoseAsync mockAmazonKinesisFirehoseAsync;
     @Mock
-    private FirehoseProcessor.Factory mockFirehoseProcessorFactory;
+    private Factory mockFirehoseProcessorFactory;
     @Mock
     private FirehoseConfigurationProvider mockFirehoseConfigurationProvider;
+    @Mock
+    private S3Sender mockS3Sender;
 
     private FirehoseProcessorSupplier firehoseProcessorSupplier;
 
     @Before
     public void setUp() {
         firehoseProcessorSupplier = new FirehoseProcessorSupplier(mockFirehoseProcessorLogger,
-                mockFirehoseCountersAndTimer, () -> mockBatch, mockAmazonKinesisFirehoseAsync,
-                mockFirehoseProcessorFactory, mockFirehoseConfigurationProvider);
+                mockFirehoseCountersAndTimer, () -> mockBatch,
+                mockFirehoseProcessorFactory, mockFirehoseConfigurationProvider, mockS3Sender);
     }
 
     @After
     public void tearDown() {
-        verifyNoMoreInteractions(mockFirehoseProcessorLogger, mockFirehoseCountersAndTimer, mockTimer, mockBatch,
-                mockAmazonKinesisFirehoseAsync, mockFirehoseProcessorFactory, mockFirehoseConfigurationProvider);
+        verifyNoMoreInteractions(mockFirehoseProcessorLogger);
+        verifyNoMoreInteractions(mockFirehoseCountersAndTimer);
+        verifyNoMoreInteractions(mockTimer);
+        verifyNoMoreInteractions(mockBatch);
+        verifyNoMoreInteractions(mockAmazonKinesisFirehoseAsync);
+        verifyNoMoreInteractions(mockFirehoseProcessorFactory);
+        verifyNoMoreInteractions(mockFirehoseConfigurationProvider);
+        verifyNoMoreInteractions(mockS3Sender);
     }
 
     @Test

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseProcessorTest.java
@@ -16,14 +16,7 @@
  */
 package com.expedia.www.haystack.pipes.firehoseWriter;
 
-import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
 import com.amazonaws.services.kinesisfirehose.model.Record;
-import com.expedia.open.tracing.Span;
-import com.expedia.www.haystack.pipes.firehoseWriter.FirehoseProcessor.Factory;
-import com.expedia.www.haystack.pipes.firehoseWriter.FirehoseProcessor.Sleeper;
-import com.netflix.servo.monitor.Stopwatch;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.junit.After;
 import org.junit.Before;
@@ -38,17 +31,11 @@ import java.util.List;
 
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.FULLY_POPULATED_SPAN;
 import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
-import static com.expedia.www.haystack.pipes.firehoseWriter.FirehoseProcessor.PUT_RECORD_BATCH_ERROR_MSG;
-import static com.expedia.www.haystack.pipes.firehoseWriter.FirehoseProcessor.PUT_RECORD_BATCH_WARN_MSG;
 import static com.expedia.www.haystack.pipes.firehoseWriter.FirehoseProcessor.STARTUP_MESSAGE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -65,231 +52,102 @@ public class FirehoseProcessorTest {
     private Logger mockLogger;
     @Mock
     private FirehoseCountersAndTimer mockFirehoseCountersAndTimer;
-
     @Mock
     private Batch mockBatch;
-
-    @Mock
-    private AmazonKinesisFirehoseAsync mockAmazonKinesisFirehoseAsync;
     @Mock
     private Factory mockFactory;
     @Mock
     private FirehoseConfigurationProvider mockFirehoseConfigurationProvider;
-
-    @Mock
-    private List<Record> mockRecordList;
-    @Mock
-    private PutRecordBatchRequest mockRequest;
-    @Mock
-    private Stopwatch mockStopwatch;
-    @Mock
-    private PutRecordBatchResult mockResult;
-    @Mock
-    private Sleeper mockSleeper;
     @Mock
     private ProcessorContext mockProcessorContext;
-    @Mock
-    private FirehoseProcessor mockFirehoseProcessor;
     @Mock
     private Thread mockThread;
     @Mock
     private Runtime mockRuntime;
+    @Mock
+    private S3Sender mockS3Sender;
+    @Mock
+    private RetryCalculator mockRetryCalculator;
+    @Mock
+    private Record mockRecord;
 
     private FirehoseProcessor firehoseProcessor;
-    private Factory factory;
-    private Sleeper sleeper;
-    private int wantedNumberOfInvocationsStreamName = 2;
+    private List<Record> recordList;
 
     @Before
     public void setUp() {
         when(mockFirehoseConfigurationProvider.streamname()).thenReturn(STREAM_NAME);
         firehoseProcessor = new FirehoseProcessor(mockLogger, mockFirehoseCountersAndTimer, () -> mockBatch,
-                mockAmazonKinesisFirehoseAsync, mockFactory, mockFirehoseConfigurationProvider);
-        factory = new Factory();
-        sleeper = factory.createSleeper();
+                mockFirehoseConfigurationProvider, mockFactory, mockS3Sender);
+        recordList = Collections.singletonList(mockRecord);
     }
 
     @After
     public void tearDown() {
-        verify(mockFirehoseConfigurationProvider, times(wantedNumberOfInvocationsStreamName)).streamname();
         verify(mockLogger).info(String.format(STARTUP_MESSAGE, STREAM_NAME));
-        verifyNoMoreInteractions(mockLogger, mockFirehoseCountersAndTimer, mockBatch, mockAmazonKinesisFirehoseAsync,
-                mockFactory, mockFirehoseConfigurationProvider, mockProcessorContext);
-        verifyNoMoreInteractions(mockRecordList, mockRequest, mockStopwatch, mockResult, mockSleeper,
-                mockFirehoseProcessor, mockThread, mockRuntime);
+        verify(mockFirehoseConfigurationProvider).streamname();
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockFirehoseCountersAndTimer);
+        verifyNoMoreInteractions(mockBatch);
+        verifyNoMoreInteractions(mockFactory);
+        verifyNoMoreInteractions(mockFirehoseConfigurationProvider);
+        verifyNoMoreInteractions(mockProcessorContext);
+        verifyNoMoreInteractions(mockThread);
+        verifyNoMoreInteractions(mockRuntime);
+        verifyNoMoreInteractions(mockS3Sender);
+        verifyNoMoreInteractions(mockRetryCalculator);
+        verifyNoMoreInteractions(mockRecord);
     }
 
     @Test
-    public void testApplyEmptyList() {
-        wantedNumberOfInvocationsStreamName = 1;
-        when(mockBatch.getRecordList(any(Span.class))).thenReturn(mockRecordList);
-        when(mockRecordList.isEmpty()).thenReturn(true);
+    public void testApplyHappyCase() throws InterruptedException {
+        commonWhensForTestApply();
 
         firehoseProcessor.process(KEY, FULLY_POPULATED_SPAN);
 
-        commonVerifiesForTestApply(1);
-        verify(mockFirehoseCountersAndTimer).recordSpanArrivalDelta(FULLY_POPULATED_SPAN);
+        commonVerifiesForTestApply();
     }
 
     @Test
-    public void testApplyHappyPath() throws InterruptedException {
+    public void testApplyInterruptedException() throws InterruptedException {
         commonWhensForTestApply();
-        when(mockAmazonKinesisFirehoseAsync.putRecordBatch(any(PutRecordBatchRequest.class))).thenReturn(mockResult);
+        final InterruptedException interruptedException = new InterruptedException("Test");
+        doThrow(interruptedException).when(mockS3Sender).sendRecordsToS3(anyListOf(Record.class), any());
+        when(mockFactory.currentThread()).thenReturn(mockThread);
 
         firehoseProcessor.process(KEY, FULLY_POPULATED_SPAN);
 
-        commonVerifiesForTestApply(1);
-        commonVerifiesForTestApplyNotEmpty(1, 1);
-        verify(mockFirehoseCountersAndTimer).countSuccessesAndFailures(mockRequest, mockResult);
-        verify(mockFirehoseCountersAndTimer).recordSpanArrivalDelta(FULLY_POPULATED_SPAN);
-    }
-
-    @Test
-    public void testClose() throws InterruptedException {
-        when(mockBatch.getRecordListForShutdown()).thenReturn(mockRecordList);
-        commonWhensForTestApply();
-        when(mockAmazonKinesisFirehoseAsync.putRecordBatch(any(PutRecordBatchRequest.class))).thenReturn(mockResult);
-
-        firehoseProcessor.close();
-
-        commonVerifiesForTestApply(0);
-        commonVerifiesForTestApplyNotEmpty(1, 1);
-        verify(mockFirehoseCountersAndTimer).countSuccessesAndFailures(mockRequest, mockResult);
-        verify(mockBatch).getRecordListForShutdown();
-    }
-
-    @Test
-    public void testApplyExceptionThenSuccess() throws InterruptedException {
-        final RuntimeException testException = new RuntimeException("testApplyExceptionThenSuccess");
-        commonWhensForTestApply();
-        when(mockAmazonKinesisFirehoseAsync.putRecordBatch(any(PutRecordBatchRequest.class)))
-                .thenThrow(testException).thenReturn(mockResult);
-
-        firehoseProcessor.process(KEY, FULLY_POPULATED_SPAN);
-
-        commonVerifiesForTestApply(1);
-        commonVerifiesForTestApplyNotEmpty(2, 1);
-        verify(mockSleeper).sleep(INITIAL_RETRY_SLEEP);
-        verify(mockLogger).error(String.format(PUT_RECORD_BATCH_WARN_MSG, 0), testException);
-        verify(mockFirehoseCountersAndTimer).countSuccessesAndFailures(mockRequest, null);
-        verify(mockFirehoseCountersAndTimer).countSuccessesAndFailures(mockRequest, mockResult);
-        verify(mockFirehoseCountersAndTimer).recordSpanArrivalDelta(FULLY_POPULATED_SPAN);
-        verify(mockFirehoseCountersAndTimer).incrementExceptionCounter();
-    }
-
-    @Test
-    public void testApplyExceptionAlways() throws InterruptedException {
-        final RuntimeException testException = new RuntimeException("testApplyExceptionAlways");
-        final int retryCount = 4;
-        commonWhensForTestApply();
-        when(mockAmazonKinesisFirehoseAsync.putRecordBatch(any(PutRecordBatchRequest.class)))
-                .thenThrow(testException).thenThrow(testException).thenThrow(testException).thenReturn(mockResult);
-
-        firehoseProcessor.process(KEY, FULLY_POPULATED_SPAN);
-
-        commonVerifiesForTestApply(1);
-        commonVerifiesForTestApplyNotEmpty(retryCount, 1);
-        verify(mockSleeper).sleep(INITIAL_RETRY_SLEEP);
-        verify(mockSleeper).sleep(2 * INITIAL_RETRY_SLEEP);
-        verify(mockSleeper).sleep(4 * INITIAL_RETRY_SLEEP);
-        for(int i = 0 ; i < retryCount - 1 ; i++) {
-            verify(mockLogger).error(String.format(PUT_RECORD_BATCH_WARN_MSG, i), testException);
-        }
-        verify(mockFirehoseCountersAndTimer, times(retryCount - 1))
-                .countSuccessesAndFailures(mockRequest, null);
-        verify(mockFirehoseCountersAndTimer).countSuccessesAndFailures(mockRequest, mockResult);
-        verify(mockFirehoseCountersAndTimer, times(retryCount - 1)).incrementExceptionCounter();
-        verify(mockFirehoseCountersAndTimer).recordSpanArrivalDelta(FULLY_POPULATED_SPAN);
-    }
-
-    @Test
-    public void testApplyMaxRetrySleepExceeded() throws InterruptedException {
-        commonWhensForTestApply();
-        when(mockAmazonKinesisFirehoseAsync.putRecordBatch(any(PutRecordBatchRequest.class))).thenReturn(mockResult);
-        when(mockBatch.extractFailedRecords(
-                any(PutRecordBatchRequest.class), any(PutRecordBatchResult.class), anyInt()))
-                .thenReturn(mockRecordList);
-        when(mockResult.getFailedPutCount())
-                .thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(0);
-        when(mockFirehoseCountersAndTimer
-                .countSuccessesAndFailures(any(PutRecordBatchRequest.class), any(PutRecordBatchResult.class)))
-                .thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(0);
-
-        firehoseProcessor.process(KEY, FULLY_POPULATED_SPAN);
-
-        commonVerifiesForTestApply(1);
-        commonVerifiesForTestApplyNotEmpty(7, 7);
-        verify(mockSleeper).sleep(INITIAL_RETRY_SLEEP);
-        verify(mockSleeper).sleep(2 * INITIAL_RETRY_SLEEP);
-        verify(mockSleeper).sleep(4 * INITIAL_RETRY_SLEEP);
-        verify(mockSleeper).sleep(8 * INITIAL_RETRY_SLEEP);
-        verify(mockSleeper, times(2)).sleep(MAX_RETRY_SLEEP);
-        verify(mockFirehoseCountersAndTimer, times(7))
-                .countSuccessesAndFailures(mockRequest, mockResult);
-        verify(mockFirehoseCountersAndTimer).recordSpanArrivalDelta(FULLY_POPULATED_SPAN);
-        verify(mockBatch).extractFailedRecords(mockRequest, mockResult, 0);
-        verify(mockBatch).extractFailedRecords(mockRequest, mockResult, 1);
-        verify(mockBatch).extractFailedRecords(mockRequest, mockResult, 2);
-        verify(mockBatch).extractFailedRecords(mockRequest, mockResult, 3);
-        verify(mockBatch).extractFailedRecords(mockRequest, mockResult, 4);
-        verify(mockBatch).extractFailedRecords(mockRequest, mockResult, 5);
-        verify(mockLogger).error(String.format(PUT_RECORD_BATCH_ERROR_MSG, 1, 6));
-    }
-
-    @Test
-    public void testApplyNullResult() throws InterruptedException {
-        commonWhensForTestApply();
-        when(mockAmazonKinesisFirehoseAsync.putRecordBatch(any(PutRecordBatchRequest.class)))
-                .thenReturn(null).thenReturn(mockResult);
-        when(mockBatch.extractFailedRecords(
-                any(PutRecordBatchRequest.class), isNull(PutRecordBatchResult.class), anyInt()))
-                .thenReturn(mockRecordList);
-
-        firehoseProcessor.process(KEY, FULLY_POPULATED_SPAN);
-
-        commonVerifiesForTestApply(1);
-        commonVerifiesForTestApplyNotEmpty(2, 1);
-        verify(mockSleeper).sleep(INITIAL_RETRY_SLEEP);
-        verify(mockFirehoseCountersAndTimer).countSuccessesAndFailures(mockRequest, null);
-        verify(mockFirehoseCountersAndTimer).countSuccessesAndFailures(mockRequest, mockResult);
-        verify(mockFirehoseCountersAndTimer).recordSpanArrivalDelta(FULLY_POPULATED_SPAN);
-        verify(mockBatch).extractFailedRecords(mockRequest, null, 0);
+        commonVerifiesForTestApply();
+        verify(mockFactory).currentThread();
+        verify(mockThread).interrupt();
     }
 
     private void commonWhensForTestApply() {
-        when(mockBatch.getRecordList(any(Span.class))).thenReturn(mockRecordList);
-        when(mockRecordList.isEmpty()).thenReturn(false);
-        when(mockFactory.createPutRecordBatchRequest(anyString(), anyListOf(Record.class))).thenReturn(mockRequest);
-        when(mockFirehoseCountersAndTimer.startTimer()).thenReturn(mockStopwatch);
-        when(mockFactory.createSleeper()).thenReturn(mockSleeper);
         when(mockFirehoseConfigurationProvider.initialretrysleep()).thenReturn(INITIAL_RETRY_SLEEP);
         when(mockFirehoseConfigurationProvider.maxretrysleep()).thenReturn(MAX_RETRY_SLEEP);
+        when(mockFactory.createRetryCalculator(anyInt(), anyInt())).thenReturn(mockRetryCalculator);
+        when(mockBatch.getRecordList(any())).thenReturn(recordList);
     }
 
-    private void commonVerifiesForTestApply(int processTimes) {
-        verify(mockFirehoseCountersAndTimer, times(processTimes)).incrementRequestCounter();
-        verify(mockBatch, times(processTimes)).getRecordList(FULLY_POPULATED_SPAN);
-        //noinspection ResultOfMethodCallIgnored
-        verify(mockRecordList).isEmpty();
-    }
-
-    private void commonVerifiesForTestApplyNotEmpty(
-            int createPutRecordBatchRequestTimes, int failedPutCountTimes) throws InterruptedException {
-        verify(mockFactory, times(createPutRecordBatchRequestTimes))
-                .createPutRecordBatchRequest(STREAM_NAME, mockRecordList);
-        verify(mockFirehoseCountersAndTimer, times(createPutRecordBatchRequestTimes)).startTimer();
-        verify(mockFactory).createSleeper();
-        verify(mockSleeper).sleep(0);
-        verify(mockAmazonKinesisFirehoseAsync, times(createPutRecordBatchRequestTimes)).putRecordBatch(mockRequest);
-        verify(mockStopwatch, times(createPutRecordBatchRequestTimes)).stop();
+    private void commonVerifiesForTestApply() throws InterruptedException {
+        verify(mockFirehoseCountersAndTimer).incrementRequestCounter();
+        verify(mockBatch).getRecordList(FULLY_POPULATED_SPAN);
+        verify(mockFactory).createRetryCalculator(INITIAL_RETRY_SLEEP, MAX_RETRY_SLEEP);
         verify(mockFirehoseConfigurationProvider).initialretrysleep();
         verify(mockFirehoseConfigurationProvider).maxretrysleep();
-        verify(mockResult, times(failedPutCountTimes)).getFailedPutCount();
+        verify(mockFirehoseCountersAndTimer).recordSpanArrivalDelta(FULLY_POPULATED_SPAN);
+        verify(mockS3Sender).sendRecordsToS3(recordList, mockRetryCalculator);
+    }
+
+    @Test
+    public void testClose() {
+        firehoseProcessor.close();
+
+        verify(mockS3Sender).close();
     }
 
     @Test
     public void testInit() {
-        wantedNumberOfInvocationsStreamName = 1;
         when(mockFactory.createShutdownHook(any(FirehoseProcessor.class))).thenReturn(mockThread);
         when(mockFactory.getRuntime()).thenReturn(mockRuntime);
         firehoseProcessor.init(mockProcessorContext);
@@ -297,38 +155,12 @@ public class FirehoseProcessorTest {
 
     @Test
     public void testPunctuate() {
-        wantedNumberOfInvocationsStreamName = 1;
         firehoseProcessor.punctuate(TIMESTAMP);
     }
 
     @Test
     public void testSleeperSleep() throws InterruptedException {
-        wantedNumberOfInvocationsStreamName = 1;
-        sleeper.sleep(0);
+        new Factory().createSleeper().sleep(0);
     }
 
-    @Test
-    public void testFactoryCreatePutRecordBatchRequest() {
-        wantedNumberOfInvocationsStreamName = 1;
-        final List<Record> records = Collections.emptyList();
-        final PutRecordBatchRequest request = factory.createPutRecordBatchRequest(STREAM_NAME, records);
-
-        assertEquals(STREAM_NAME, request.getDeliveryStreamName());
-        assertEquals(records, request.getRecords());
-    }
-
-    @Test
-    public void testFactoryGetRuntime() {
-        wantedNumberOfInvocationsStreamName = 1;
-        assertSame(Runtime.getRuntime(), factory.getRuntime());
-    }
-
-    @Test
-    public void testFactoryCreateShutdownHookAndShutdownHookClass() {
-        wantedNumberOfInvocationsStreamName = 1;
-        final Thread shutdownHook = factory.createShutdownHook(mockFirehoseProcessor);
-        shutdownHook.run();
-
-        verify(mockFirehoseProcessor).close();
-    }
 }

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/RetryCalculatorTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/RetryCalculatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RetryCalculatorTest {
+    private static final int INITIAL_RETRY_SLEEP = 10;
+    private static final int MAX_RETRY_SLEEP = 8 * INITIAL_RETRY_SLEEP;
+
+    private RetryCalculator retryCalculator;
+
+    @Before
+    public void setUp() {
+        retryCalculator = new RetryCalculator(INITIAL_RETRY_SLEEP, MAX_RETRY_SLEEP);
+    }
+
+    @Test
+    public void testCalculateSleepMillisAndIsTryCountAtLimit() {
+        assertEquals(0, retryCalculator.calculateSleepMillis());
+        assertFalse(retryCalculator.isTryCountBeyondLimit());
+        assertEquals(1, retryCalculator.getUnboundedTryCount());
+
+        assertEquals(INITIAL_RETRY_SLEEP, retryCalculator.calculateSleepMillis());
+        assertFalse(retryCalculator.isTryCountBeyondLimit());
+        assertEquals(2, retryCalculator.getUnboundedTryCount());
+
+        assertEquals(2 * INITIAL_RETRY_SLEEP, retryCalculator.calculateSleepMillis());
+        assertFalse(retryCalculator.isTryCountBeyondLimit());
+        assertEquals(3, retryCalculator.getUnboundedTryCount());
+
+        assertEquals(4 * INITIAL_RETRY_SLEEP, retryCalculator.calculateSleepMillis());
+        assertFalse(retryCalculator.isTryCountBeyondLimit());
+        assertEquals(4, retryCalculator.getUnboundedTryCount());
+
+        assertEquals(MAX_RETRY_SLEEP, retryCalculator.calculateSleepMillis());
+        assertFalse(retryCalculator.isTryCountBeyondLimit());
+        assertEquals(5, retryCalculator.getUnboundedTryCount());
+
+        assertEquals(MAX_RETRY_SLEEP, retryCalculator.calculateSleepMillis());
+        assertTrue(retryCalculator.isTryCountBeyondLimit());
+        assertEquals(6, retryCalculator.getUnboundedTryCount());
+    }
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/S3SenderTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/S3SenderTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseAsync;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import com.netflix.servo.monitor.Stopwatch;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class S3SenderTest {
+    private static final String STREAM_NAME = RANDOM.nextLong() + "STREAM_NAME";
+    private static final int SLEEP_MILLIS = RANDOM.nextInt();
+    private static final int INITIAL_RETRY_SLEEP = RANDOM.nextInt(Byte.MAX_VALUE);
+    private static final Integer MAX_RETRY_SLEEP = RANDOM.nextInt(Byte.MAX_VALUE);
+
+    @Mock
+    private Supplier<Batch> mockSupplierBatch;
+    @Mock
+    private Batch mockBatch;
+    @Mock
+    private FirehoseProcessor.Sleeper mockSleeper;
+    @Mock
+    private Factory mockFactory;
+    @Mock
+    private FirehoseConfigurationProvider mockFirehoseConfigurationProvider;
+    @Mock
+    private FirehoseCountersAndTimer mockFirehoseCountersAndTimer;
+    @Mock
+    private AmazonKinesisFirehoseAsync mockAmazonKinesisFirehoseAsync;
+    @Mock
+    private ArrayBlockingQueue<BlockingQueueEntry> mockArrayBlockingQueue;
+    @Mock
+    private RetryCalculator mockRetryCalculator;
+    @Mock
+    private Record mockRecord;
+    @Mock
+    private PutRecordBatchRequest mockPutRecordBatchRequest;
+    @Mock
+    private Stopwatch mockStopwatch;
+    @Mock
+    private Future<PutRecordBatchResult> mockPutRecordBatchResultFuture;
+    @Mock
+    private BlockingQueueEntry mockBlockingQueueEntry;
+    @Mock
+    private Thread mockThread;
+
+    private S3Sender s3Sender;
+    private List<Record> recordList;
+
+    @Before
+    public void setUp() {
+        when(mockSupplierBatch.get()).thenReturn(mockBatch);
+        when(mockFirehoseConfigurationProvider.streamname()).thenReturn(STREAM_NAME);
+        s3Sender = new S3Sender(mockSupplierBatch, mockSleeper, mockFactory, mockFirehoseConfigurationProvider,
+                mockFirehoseCountersAndTimer, mockAmazonKinesisFirehoseAsync, mockArrayBlockingQueue);
+        recordList= new ArrayList<>(Collections.singleton(mockRecord));
+    }
+
+    @After
+    public void tearDown() {
+        verify(mockSupplierBatch).get();
+        verify(mockFirehoseConfigurationProvider).streamname();
+
+        verifyNoMoreInteractions(mockSupplierBatch);
+        verifyNoMoreInteractions(mockBatch);
+        verifyNoMoreInteractions(mockSleeper);
+        verifyNoMoreInteractions(mockFactory);
+        verifyNoMoreInteractions(mockFirehoseConfigurationProvider);
+        verifyNoMoreInteractions(mockFirehoseCountersAndTimer);
+        verifyNoMoreInteractions(mockAmazonKinesisFirehoseAsync);
+        verifyNoMoreInteractions(mockArrayBlockingQueue);
+        verifyNoMoreInteractions(mockRetryCalculator);
+        verifyNoMoreInteractions(mockRecord);
+        verifyNoMoreInteractions(mockPutRecordBatchRequest);
+        verifyNoMoreInteractions(mockStopwatch);
+        verifyNoMoreInteractions(mockPutRecordBatchResultFuture);
+        verifyNoMoreInteractions(mockThread);
+    }
+
+    @Test
+    public void testSendRecordsToS3EmptyList() throws InterruptedException {
+        s3Sender.sendRecordsToS3(Collections.emptyList(), mockRetryCalculator);
+    }
+
+    private void whensForSendRecordsToS3NonEmptyList() {
+        when(mockRetryCalculator.calculateSleepMillis()).thenReturn(SLEEP_MILLIS);
+        when(mockFactory.createPutRecordBatchRequest(anyString(), anyListOf(Record.class)))
+                .thenReturn(mockPutRecordBatchRequest);
+        when(mockFirehoseCountersAndTimer.startTimer()).thenReturn(mockStopwatch);
+        when(mockAmazonKinesisFirehoseAsync.putRecordBatchAsync(any()))
+                .thenReturn(mockPutRecordBatchResultFuture);
+        when(mockFactory.createBlockingQueueEntry(any(), any(), any(), any(), any()))
+                .thenReturn(mockBlockingQueueEntry);
+    }
+
+    private void verifiesForSendRecordsToS3NonEmptyList() throws InterruptedException {
+        verify(mockRetryCalculator).calculateSleepMillis();
+        verify(mockSleeper).sleep(SLEEP_MILLIS);
+        verify(mockFactory).createPutRecordBatchRequest(STREAM_NAME, recordList);
+        verify(mockFirehoseCountersAndTimer).startTimer();
+        verify(mockAmazonKinesisFirehoseAsync).putRecordBatchAsync(mockPutRecordBatchRequest);
+        verify(mockFactory).createBlockingQueueEntry(mockStopwatch, mockRetryCalculator, mockPutRecordBatchRequest,
+                mockBatch, mockPutRecordBatchResultFuture);
+        verify(mockArrayBlockingQueue).put(mockBlockingQueueEntry);
+    }
+
+    @Test
+    public void testSendRecordsToS3NonEmptyList() throws InterruptedException {
+        whensForSendRecordsToS3NonEmptyList();
+
+        s3Sender.sendRecordsToS3(recordList, mockRetryCalculator);
+
+        verifiesForSendRecordsToS3NonEmptyList();
+    }
+
+    @Test
+    public void testCloseHappyCase() throws InterruptedException {
+        whensForClose();
+        whensForSendRecordsToS3NonEmptyList();
+
+        s3Sender.close();
+
+        verifiesForClose();
+        verifiesForSendRecordsToS3NonEmptyList();
+    }
+
+    @Test
+    public void testCloseInterruptedException() throws InterruptedException {
+        whensForClose();
+        final InterruptedException interruptedException = new InterruptedException();
+        doThrow(interruptedException).when(mockSleeper).sleep(anyLong());
+        when(mockRetryCalculator.calculateSleepMillis()).thenReturn(SLEEP_MILLIS);
+        when(mockFactory.currentThread()).thenReturn(mockThread);
+
+        s3Sender.close();
+
+        verifiesForClose();
+        verify(mockRetryCalculator).calculateSleepMillis();
+        verify(mockSleeper).sleep(SLEEP_MILLIS);
+        verify(mockFactory).currentThread();
+        verify(mockThread).interrupt();
+    }
+
+    private void whensForClose() {
+        when(mockBatch.getRecordListForShutdown()).thenReturn(recordList);
+        when(mockFirehoseConfigurationProvider.initialretrysleep()).thenReturn(INITIAL_RETRY_SLEEP);
+        when(mockFirehoseConfigurationProvider.maxretrysleep()).thenReturn(MAX_RETRY_SLEEP);
+        when(mockFactory.createRetryCalculator(anyInt(), anyInt())).thenReturn(mockRetryCalculator);
+    }
+
+    private void verifiesForClose() {
+        verify(mockBatch).getRecordListForShutdown();
+        verify(mockFirehoseConfigurationProvider).initialretrysleep();
+        verify(mockFirehoseConfigurationProvider).maxretrysleep();
+        verify(mockFactory).createRetryCalculator(INITIAL_RETRY_SLEEP, MAX_RETRY_SLEEP);
+    }
+
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/ShutdownHookTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/ShutdownHookTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ShutdownHookTest {
+    @Mock
+    private FirehoseProcessor mockFirehoseProcessor;
+
+    private ShutdownHook shutdownHook;
+
+    @Before
+    public void setUp() {
+        shutdownHook = new ShutdownHook(mockFirehoseProcessor);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockFirehoseProcessor);
+    }
+
+    @Test
+    public void testRun() {
+        shutdownHook.run();
+
+        verify(mockFirehoseProcessor).close();
+    }
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
@@ -16,6 +16,7 @@
  */
 package com.expedia.www.haystack.pipes.firehoseWriter;
 
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.ClientConfiguration;
@@ -33,10 +34,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import static com.expedia.www.haystack.pipes.commons.CommonConstants.SPAN_ARRIVAL_TIMER_NAME;
 import static com.expedia.www.haystack.pipes.commons.CommonConstants.SUBSYSTEM;
 import static com.expedia.www.haystack.pipes.firehoseWriter.Constants.APPLICATION;
+import static com.expedia.www.haystack.pipes.firehoseWriter.SpringConfig.CORE_POOL_SIZE;
+import static com.expedia.www.haystack.pipes.firehoseWriter.SpringConfig.MAX_POOL_SIZE;
+import static com.expedia.www.haystack.pipes.firehoseWriter.SpringConfig.QUEUE_CAPACITY;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -63,6 +68,14 @@ public class SpringConfigTest {
     private Counter mockCounter;
     @Mock
     private HealthController mockHealthController;
+    @Mock
+    private S3Sender mockS3Sender;
+    @Mock
+    private Logger mockLogger;
+    @Mock
+    private FirehoseCountersAndTimer mockFirehoseCountersAndTimer;
+    @Mock
+    private ArrayBlockingQueue<BlockingQueueEntry> mockArrayBlockingQueue;
 
     private SpringConfig springConfig;
 
@@ -73,8 +86,15 @@ public class SpringConfigTest {
 
     @After
     public void tearDown() {
-        verifyNoMoreInteractions(mockMetricObjects, mockFirehoseConfigurationProvider, mockTimer, mockCounter,
-                mockHealthController);
+        verifyNoMoreInteractions(mockMetricObjects);
+        verifyNoMoreInteractions(mockFirehoseConfigurationProvider);
+        verifyNoMoreInteractions(mockTimer);
+        verifyNoMoreInteractions(mockCounter);
+        verifyNoMoreInteractions(mockHealthController);
+        verifyNoMoreInteractions(mockS3Sender);
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockFirehoseCountersAndTimer);
+        verifyNoMoreInteractions(mockArrayBlockingQueue);
     }
 
     @Test
@@ -188,6 +208,42 @@ public class SpringConfigTest {
         final Logger logger = springConfig.batchLogger();
 
         assertEquals(Batch.class.getName(), logger.getName());
+    }
+
+    @Test
+    public void testFirehoseConsumerLogger() {
+        final Logger logger = springConfig.firehoseConsumerLogger();
+
+        assertEquals(FirehoseConsumer.class.getName(), logger.getName());
+    }
+
+    @Test
+    public void testThreadPoolTaskExecutor() {
+        final ThreadPoolTaskExecutor taskExecutor = (ThreadPoolTaskExecutor) springConfig.threadPoolTaskExecutor();
+
+        // No way to verify that taskExecutor.setBeanName() was called
+        assertEquals(CORE_POOL_SIZE, taskExecutor.getCorePoolSize());
+        assertEquals(MAX_POOL_SIZE, taskExecutor.getMaxPoolSize());
+        assertEquals(APPLICATION, taskExecutor.getThreadNamePrefix());
+        assertNotNull(taskExecutor.getThreadPoolExecutor()); // proves that taskExecutor.initialize() was called
+    }
+
+    @Test
+    public void testFirehoseConsumer() {
+        final FirehoseConsumer firehoseConsumer = springConfig.firehoseConsumer(
+                mockS3Sender, mockLogger, mockFirehoseCountersAndTimer, mockArrayBlockingQueue);
+
+        assertSame(mockS3Sender, firehoseConsumer.s3Sender);
+        assertSame(mockLogger, firehoseConsumer.logger);
+        assertSame(mockFirehoseCountersAndTimer, firehoseConsumer.firehoseCountersAndTimer);
+        assertSame(mockArrayBlockingQueue, firehoseConsumer.arrayBlockingQueue);
+    }
+
+    @Test
+    public void testArrayBlockingQueue() {
+        final ArrayBlockingQueue<BlockingQueueEntry> arrayBlockingQueue = springConfig.arrayBlockingQueue();
+
+        assertEquals(QUEUE_CAPACITY, arrayBlockingQueue.remainingCapacity());
     }
 
     @Test


### PR DESCRIPTION
to improve firehose-writer throughput.