### PR TITLE
Use the "fat" HaystackCompositePhoneNumberFinder instead of the seven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <commons-pool2.version>2.5.0</commons-pool2.version>
         <commons-text.version>1.1</commons-text.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
-        <haystack-secrets-commons.version>1.0.5</haystack-secrets-commons.version>
+        <haystack-secrets-commons.version>1.0.6</haystack-secrets-commons.version>
         <haystack-metrics.version>2.0.1</haystack-metrics.version>
         <haystack-logback-metrics-appender.version>1.0.5</haystack-logback-metrics-appender.version>
         <haystack-log4j-metrics-appender.version>1.0.3</haystack-log4j-metrics-appender.version>

--- a/secret-detector/src/main/resources/finders_default.xml
+++ b/secret-detector/src/main/resources/finders_default.xml
@@ -11,38 +11,43 @@
 		<enabled>true</enabled>
 	</finder>
 	<finder>
+		<class>com.expedia.www.haystack.commons.secretDetector.HaystackCompositePhoneNumberFinder</class>
+		<enabled>true</enabled>
+	</finder>
+	<finder>
 		<class>com.expedia.www.haystack.commons.secretDetector.HaystackPhoneNumberFinder</class>
 		<region>CANADA</region>
-		<enabled>true</enabled>
+		<enabled>false</enabled>
 	</finder>
 	<finder>
 		<class>com.expedia.www.haystack.commons.secretDetector.HaystackPhoneNumberFinder</class>
 		<region>FRANCE</region>
-		<enabled>true</enabled>
+		<enabled>false</enabled>
 	</finder>
 	<finder>
 		<class>com.expedia.www.haystack.commons.secretDetector.HaystackPhoneNumberFinder</class>
 		<region>GERMANY</region>
-		<enabled>true</enabled>
+		<enabled>false</enabled>
 	</finder>
 	<finder>
 		<class>com.expedia.www.haystack.commons.secretDetector.HaystackPhoneNumberFinder</class>
 		<region>ITALY</region>
-		<enabled>true</enabled>
+		<enabled>false</enabled>
 	</finder>
 	<finder>
 		<class>com.expedia.www.haystack.commons.secretDetector.HaystackPhoneNumberFinder</class>
 		<region>JAPAN</region>
-		<enabled>true</enabled>
+		<enabled>false</enabled>
 	</finder>
 	<finder>
 		<class>com.expedia.www.haystack.commons.secretDetector.HaystackPhoneNumberFinder</class>
 		<region>UNITED_KINGDOM</region>
-		<enabled>true</enabled>
+		<enabled>false</enabled>
 	</finder>
 	<finder>
 		<class>com.expedia.www.haystack.commons.secretDetector.HaystackPhoneNumberFinder</class>
 		<region>UNITED_STATES</region>
+        <enabled>false</enabled>
 	</finder>
 	<finder>
 		<class>com.expedia.www.haystack.commons.secretDetector.HaystackCompositeCreditCardFinder</class>

--- a/secret-detector/src/test/resources/finders_default.xml
+++ b/secret-detector/src/test/resources/finders_default.xml
@@ -7,6 +7,7 @@
 	</finder>
 	<finder>
 		<class>com.expedia.www.haystack.commons.secretDetector.HaystackPhoneNumberFinder</class>
+		<region>UNITED_STATES</region>
 		<enabled>true</enabled>
 	</finder>
 	<finder>


### PR DESCRIPTION
"skinny" HaystackPhoneNumberFinder objects (one for each region) to see
if "fat" is faster than "skinny" at prod volume.