### PR TITLE
Prod issue documented in

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseCollector.java
@@ -34,8 +34,13 @@ public interface FirehoseCollector {
     /**
      * Maximum record size in bytes; see https://docs.aws.amazon.com/firehose/latest/dev/limits.html to read that "The
      * maximum size of a record sent to Kinesis Data Firehose, before base64-encoding, is 1,000 KB."
+     * Error messages received from AWS Kinesis Firehose (documented in
+     * https://github.com/ExpediaDotCom/haystack-pipes/issues/251) make it clear than the limit should
+     * be 1024 * 1000; for details about why it is now 999 * 1000 see
+     * https://github.com/ExpediaDotCom/haystack-pipes/issues/251#issuecomment-426733404.
+     *
      */
-    int MAX_BYTES_IN_RECORD = 1000 * 1000; // ~ 1 MB
+    int MAX_BYTES_IN_RECORD = 999 * 1000; // ~ 1 MB
 
     /**
      * Maximum number of Records allowed in a batch; see https://docs.aws.amazon.com/firehose/latest/dev/limits.html to

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseStringBufferCollector.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/FirehoseStringBufferCollector.java
@@ -1,11 +1,30 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.expedia.www.haystack.pipes.firehoseWriter;
 
 import com.amazonaws.services.kinesisfirehose.model.Record;
 import com.netflix.servo.util.VisibleForTesting;
 import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -13,13 +32,16 @@ import java.util.Optional;
 public class FirehoseStringBufferCollector implements FirehoseCollector {
     @VisibleForTesting
     static final int MAX_RECORDS_IN_BATCH_FOR_STRING_BUFFER_COLLECTOR = 4;
+    static final String BYTE_BUFFER_LENGTH_TOO_LARGE = "Byte buffer length [%d] is too large: %s";
 
     private final Factory factory;
     private final int maxBatchInterval;
     private final int maxRecordsInBatch;
     private final int maxBytesInRecord;
+    private final Logger logger;
 
-    private StringBuilder buffer;
+    @VisibleForTesting
+    StringBuilder buffer; // TODO Replace with "final byte[] bytes" to minimize garbage creation
     private List<Record> recordsInBatch;
     private long batchLastCreatedAt;
     private int totalBatchSize;
@@ -29,18 +51,21 @@ public class FirehoseStringBufferCollector implements FirehoseCollector {
     }
 
     FirehoseStringBufferCollector(int maxBatchInterval) {
-        this(new Factory(), MAX_BYTES_IN_RECORD, MAX_RECORDS_IN_BATCH_FOR_STRING_BUFFER_COLLECTOR, maxBatchInterval);
+        this(new Factory(), MAX_BYTES_IN_RECORD, MAX_RECORDS_IN_BATCH_FOR_STRING_BUFFER_COLLECTOR, maxBatchInterval,
+                LoggerFactory.getLogger(FirehoseStringBufferCollector.class));
     }
 
     FirehoseStringBufferCollector(Factory factory,
                                   int maxBytesInRecord,
                                   int maxRecordsInBatch,
-                                  int maxBatchInterval) {
+                                  int maxBatchInterval,
+                                  Logger logger) {
         Validate.notNull(factory);
         this.factory = factory;
         this.maxBatchInterval = maxBatchInterval;
         this.maxBytesInRecord = maxBytesInRecord;
         this.maxRecordsInBatch = maxRecordsInBatch;
+        this.logger = logger;
         initializeBuffer();
         initializeBatch();
     }
@@ -69,7 +94,7 @@ public class FirehoseStringBufferCollector implements FirehoseCollector {
         }
 
         if (shouldCreateNewRecordDueToRecordSize(data)) {
-            final Optional<Record> record = createRecordFromBuffer();
+            final Optional<Record> record = createRecordFromBuffer(buffer);
             record.ifPresent(recordsInBatch::add);
 
             final List<Record> returnBatch = createNewBatchIfFull();
@@ -84,7 +109,7 @@ public class FirehoseStringBufferCollector implements FirehoseCollector {
 
     @Override
     public List<Record> createIncompleteBatch() {
-        final Optional<Record> record = createRecordFromBuffer();
+        final Optional<Record> record = createRecordFromBuffer(buffer);
         record.ifPresent(recordsInBatch::add);
         final List<Record> returnBatch = recordsInBatch;
         initializeBatch();
@@ -114,13 +139,17 @@ public class FirehoseStringBufferCollector implements FirehoseCollector {
     }
 
     @VisibleForTesting
-    Optional<Record> createRecordFromBuffer() {
-        if (bufferSize() == 0) {
+    Optional<Record> createRecordFromBuffer(StringBuilder stringBuilder) {
+        if (stringBuilder.length() == 0) {
             return Optional.empty();
         }
 
         //add the current buffer to a record and clear the buffer
-        final Record record = new Record().withData(ByteBuffer.wrap(buffer.toString().getBytes()));
+        final byte[] bytes = stringBuilder.toString().getBytes();
+        if(bytes.length > MAX_BYTES_IN_RECORD) {
+            logger.error(BYTE_BUFFER_LENGTH_TOO_LARGE, bytes.length, Arrays.toString(bytes));
+        }
+        final Record record = new Record().withData(ByteBuffer.wrap(bytes));
         initializeBuffer();
         return Optional.of(record);
     }


### PR DESCRIPTION
https://github.com/ExpediaDotCom/haystack-pipes/issues/251
occurred again; decrease the size of the buffer, log an error with the
offending byte array when the error occurs, put a TODO to use a byte
array instead of a StringBuilder