### PR TITLE
Add FailedRecordExtractor with a logError() method so that there will

### DIFF
--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/InternalFailureErrorLogger.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/InternalFailureErrorLogger.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import org.slf4j.Logger;
+
+class InternalFailureErrorLogger {
+    private final Logger logger;
+
+    InternalFailureErrorLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    void logError(PutRecordBatchRequest request,
+                  PutRecordBatchResult result,
+                  int retryCount) {
+        logger.error(String.format(FailedRecordExtractor.INTERNAL_FAILURE_MSG,
+                request.getRecords().size(), retryCount, result.getSdkResponseMetadata().getRequestId()));
+    }
+}

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfig.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfig.java
@@ -169,10 +169,16 @@ class SpringConfig {
     }
 
     @Bean
+    Logger internalFailureErrorLoggerLogger() {
+        return LoggerFactory.getLogger(InternalFailureErrorLogger.class);
+    }
+
+    @Bean
     @Autowired
     FailedRecordExtractor failedRecordExtractor(Logger failedRecordExtractorLogger,
-                                                Counter throttledCounter) {
-        return new FailedRecordExtractor(failedRecordExtractorLogger, throttledCounter);
+                                                Counter throttledCounter,
+                                                InternalFailureErrorLogger internalFailureErrorLogger) {
+        return new FailedRecordExtractor(failedRecordExtractorLogger, throttledCounter, internalFailureErrorLogger);
     }
 
     @Bean
@@ -202,6 +208,12 @@ class SpringConfig {
     }
 
     // Beans without unit tests ////////////////////////////////////////////////////////////////////////////////////////
+    @Bean
+    @Autowired
+    InternalFailureErrorLogger internalFailureErrorLogger(Logger internalFailureErrorLoggerLogger) {
+        return new InternalFailureErrorLogger(internalFailureErrorLoggerLogger);
+    }
+
     @Bean
     @Autowired
     AmazonKinesisFirehoseAsync amazonKinesisFirehoseAsync(EndpointConfiguration endpointConfiguration,

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfig.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfig.java
@@ -174,6 +174,11 @@ class SpringConfig {
     }
 
     @Bean
+    Logger unexpectedExceptionLoggerLogger() {
+        return LoggerFactory.getLogger(UnexpectedExceptionLogger.class);
+    }
+
+    @Bean
     @Autowired
     FailedRecordExtractor failedRecordExtractor(Logger failedRecordExtractorLogger,
                                                 Counter throttledCounter,
@@ -212,6 +217,12 @@ class SpringConfig {
     @Autowired
     InternalFailureErrorLogger internalFailureErrorLogger(Logger internalFailureErrorLoggerLogger) {
         return new InternalFailureErrorLogger(internalFailureErrorLoggerLogger);
+    }
+
+    @Bean
+    @Autowired
+    UnexpectedExceptionLogger unexpectedExceptionLogger(Logger unexpectedExceptionLoggerLogger) {
+        return new UnexpectedExceptionLogger(unexpectedExceptionLoggerLogger);
     }
 
     @Bean

--- a/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/UnexpectedExceptionLogger.java
+++ b/firehose-writer/src/main/java/com/expedia/www/haystack/pipes/firehoseWriter/UnexpectedExceptionLogger.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import org.slf4j.Logger;
+
+class UnexpectedExceptionLogger {
+    static final String UNEXPECTED_EXCEPTION_MSG = "Unexpected exception received from AWS Firehose, will retry all records";
+    private final Logger logger;
+
+    UnexpectedExceptionLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    void logError(Exception exception) {
+        logger.error(UNEXPECTED_EXCEPTION_MSG, exception);
+    }
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/InternalFailureErrorLoggerTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/InternalFailureErrorLoggerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import com.amazonaws.ResponseMetadata;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static com.expedia.www.haystack.pipes.firehoseWriter.FailedRecordExtractor.INTERNAL_FAILURE_MSG;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InternalFailureErrorLoggerTest {
+    private static final int RETRY_COUNT = RANDOM.nextInt(Byte.MAX_VALUE);
+    private static final int SIZE = RANDOM.nextInt(Byte.MAX_VALUE);
+    private static final String REQUEST_ID = RANDOM.nextLong() + "REQUEST_ID";
+
+    @Mock
+    private Logger mockLogger;
+    @Mock
+    private PutRecordBatchRequest mockPutRecordBatchRequest;
+    @Mock
+    private PutRecordBatchResult mockPutRecordBatchResult;
+    @Mock
+    private ResponseMetadata mockSdkResponseMetadata;
+    @Mock
+    private Record mockRecord;
+
+    private List<Record> records;
+    private InternalFailureErrorLogger internalFailureErrorLogger;
+
+    @Before
+    public void setUp() {
+        records = new ArrayList<>(SIZE);
+        for(int i = 0 ; i < SIZE ; i++) {
+            records.add(mockRecord);
+        }
+        internalFailureErrorLogger = new InternalFailureErrorLogger(mockLogger);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockPutRecordBatchRequest);
+        verifyNoMoreInteractions(mockPutRecordBatchResult);
+        verifyNoMoreInteractions(mockSdkResponseMetadata);
+        verifyNoMoreInteractions(mockRecord);
+    }
+
+    @Test
+    public void testLogError() {
+        when(mockPutRecordBatchRequest.getRecords()).thenReturn(records);
+        when(mockPutRecordBatchResult.getSdkResponseMetadata()).thenReturn(mockSdkResponseMetadata);
+        when(mockSdkResponseMetadata.getRequestId()).thenReturn(REQUEST_ID);
+
+        internalFailureErrorLogger.logError(mockPutRecordBatchRequest, mockPutRecordBatchResult, RETRY_COUNT);
+
+        verify(mockPutRecordBatchRequest).getRecords();
+        verify(mockPutRecordBatchResult).getSdkResponseMetadata();
+        verify(mockSdkResponseMetadata).getRequestId();
+        verify(mockLogger).error(String.format(INTERNAL_FAILURE_MSG, SIZE, RETRY_COUNT, REQUEST_ID));
+    }
+
+}

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
@@ -222,6 +222,13 @@ public class SpringConfigTest {
     }
 
     @Test
+    public void testInternalFailureErrorLoggerLogger() {
+        final Logger logger = springConfig.internalFailureErrorLoggerLogger();
+
+        assertEquals(InternalFailureErrorLogger.class.getName(), logger.getName());
+    }
+
+    @Test
     public void testEndpointConfiguration() {
         final EndpointConfiguration endpointConfiguration = springConfig.endpointConfiguration(URL, SIGNING_REGION);
 

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/SpringConfigTest.java
@@ -229,6 +229,13 @@ public class SpringConfigTest {
     }
 
     @Test
+    public void testUnexpectedExceptionLoggerLogger() {
+        final Logger logger = springConfig.unexpectedExceptionLoggerLogger();
+
+        assertEquals(UnexpectedExceptionLogger.class.getName(), logger.getName());
+    }
+
+    @Test
     public void testEndpointConfiguration() {
         final EndpointConfiguration endpointConfiguration = springConfig.endpointConfiguration(URL, SIGNING_REGION);
 

--- a/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/UnexpectedExceptionLoggerTest.java
+++ b/firehose-writer/src/test/java/com/expedia/www/haystack/pipes/firehoseWriter/UnexpectedExceptionLoggerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.firehoseWriter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import static com.expedia.www.haystack.pipes.firehoseWriter.UnexpectedExceptionLogger.UNEXPECTED_EXCEPTION_MSG;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnexpectedExceptionLoggerTest {
+
+    @Mock
+    private Logger mockLogger;
+    @Mock
+    private Exception mockException;
+
+    private UnexpectedExceptionLogger unexpectedExceptionLogger;
+
+    @Before
+    public void setUp() {
+        unexpectedExceptionLogger = new UnexpectedExceptionLogger(mockLogger);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockException);
+    }
+
+    @Test
+    public void testLogError() {
+        unexpectedExceptionLogger.logError(mockException);
+
+        verify(mockLogger).error(UNEXPECTED_EXCEPTION_MSG, mockException);
+    }
+
+}

--- a/http-poster/src/main/java/com/expedia/www/haystack/pipes/httpPoster/InvalidProtocolBufferExceptionLogger.java
+++ b/http-poster/src/main/java/com/expedia/www/haystack/pipes/httpPoster/InvalidProtocolBufferExceptionLogger.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.httpPoster;
+
+import com.expedia.open.tracing.Span;
+import com.expedia.www.haystack.pipes.commons.CommonConstants;
+import org.slf4j.Logger;
+
+import static com.expedia.www.haystack.pipes.commons.CommonConstants.PROTOBUF_ERROR_MSG;
+
+class InvalidProtocolBufferExceptionLogger {
+    private final Logger logger;
+
+    InvalidProtocolBufferExceptionLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    void logError(Span span, Exception exception) {
+        logger.error(String.format(PROTOBUF_ERROR_MSG, span.toString(), exception.getMessage()), exception);
+    }
+
+}

--- a/http-poster/src/main/java/com/expedia/www/haystack/pipes/httpPoster/SpringConfig.java
+++ b/http-poster/src/main/java/com/expedia/www/haystack/pipes/httpPoster/SpringConfig.java
@@ -113,7 +113,18 @@ public class SpringConfig {
         return LoggerFactory.getLogger(HttpPostAction.class);
     }
 
+    @Bean
+    Logger invalidProtocolBufferExceptionLoggerLogger() {
+        return LoggerFactory.getLogger(InvalidProtocolBufferExceptionLogger.class);
+    }
+
     // Beans without unit tests
+    @Bean
+    InvalidProtocolBufferExceptionLogger invalidProtocolBufferExceptionLogger(
+            Logger invalidProtocolBufferExceptionLoggerLogger) {
+        return new InvalidProtocolBufferExceptionLogger(invalidProtocolBufferExceptionLoggerLogger);
+    }
+
     @Bean
     HttpPostConfigurationProvider httpPostConfigurationProvider() {
         return new HttpPostConfigurationProvider();

--- a/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/InvalidProtocolBufferExceptionLoggerTest.java
+++ b/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/InvalidProtocolBufferExceptionLoggerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.httpPoster;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import static com.expedia.www.haystack.pipes.commons.CommonConstants.PROTOBUF_ERROR_MSG;
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.NO_TAGS_SPAN;
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InvalidProtocolBufferExceptionLoggerTest {
+    private static final String MESSAGE = RANDOM.nextLong() + "MESSAGE";
+
+    @Mock
+    private Logger mockLogger;
+    @Mock
+    private Exception mockException;
+
+    private InvalidProtocolBufferExceptionLogger invalidProtocolBufferExceptionLogger;
+
+    @Before
+    public void setUp() {
+        invalidProtocolBufferExceptionLogger = new InvalidProtocolBufferExceptionLogger(mockLogger);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockException);
+    }
+
+    @Test
+    public void testLogError() {
+        when(mockException.getMessage()).thenReturn(MESSAGE);
+
+        invalidProtocolBufferExceptionLogger.logError(NO_TAGS_SPAN, mockException);
+
+        verify(mockException).getMessage();
+        final String msg = String.format(PROTOBUF_ERROR_MSG, NO_TAGS_SPAN.toString(), MESSAGE);
+        final String expected = "Exception printing Span [" + NO_TAGS_SPAN.toString() + "]"
+                + "; received message [" + MESSAGE + "]";
+        assertEquals(expected, msg);
+        verify(mockLogger).error(msg, mockException);
+    }
+
+}

--- a/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/SpringConfigTest.java
+++ b/http-poster/src/test/java/com/expedia/www/haystack/pipes/httpPoster/SpringConfigTest.java
@@ -96,6 +96,13 @@ public class SpringConfigTest {
         assertEquals(HttpPostIsActiveController.class.getName(), logger.getName());
     }
 
+    @Test
+    public void testInvalidProtocolBufferExceptionLogger() {
+        final Logger logger = springConfig.invalidProtocolBufferExceptionLoggerLogger();
+
+        assertEquals(InvalidProtocolBufferExceptionLogger.class.getName(), logger.getName());
+    }
+
     // All of the other beans in SpringConfig use default constructors, or use arguments provided by other Spring beans
     // in SpringConfig, so tests on the methods that create those beans have little value.
 }

--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/SpringConfig.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/SpringConfig.java
@@ -42,6 +42,8 @@ import com.expedia.www.haystack.pipes.secretDetector.config.SpringWiredWhiteList
 import com.expedia.www.haystack.pipes.secretDetector.mains.ProtobufSpanMaskerToKafkaTransformer;
 import com.expedia.www.haystack.pipes.secretDetector.mains.ProtobufSpanToEmailInKafkaTransformer;
 import com.expedia.www.haystack.pipes.secretDetector.mains.ProtobufToDetectorAction;
+import com.expedia.www.haystack.pipes.secretDetector.actions.FromAddressExceptionLogger;
+import com.expedia.www.haystack.pipes.secretDetector.actions.ToAddressExceptionLogger;
 import com.netflix.servo.monitor.Counter;
 import com.netflix.servo.monitor.Timer;
 import org.cfg4j.provider.ConfigurationProvider;
@@ -121,6 +123,16 @@ public class SpringConfig {
     @Bean
     Logger emailerDetectedActionLogger() {
         return LoggerFactory.getLogger(EmailerDetectedAction.class);
+    }
+
+    @Bean
+    Logger fromAddressExceptionLoggerLogger() {
+        return LoggerFactory.getLogger(FromAddressExceptionLogger.class);
+    }
+
+    @Bean
+    Logger toAddressExceptionLoggerLogger() {
+        return LoggerFactory.getLogger(ToAddressExceptionLogger.class);
     }
 
     @Bean
@@ -270,9 +282,23 @@ public class SpringConfig {
     EmailerDetectedActionFactory emailerDetectedActionFactory(EmailerDetectedAction.MimeMessageFactory mimeMessageFactory,
                                                               Logger emailerDetectedActionLogger,
                                                               EmailerDetectedAction.Sender sender,
-                                                              SecretsEmailConfigurationProvider secretsEmailConfigurationProvider) {
+                                                              SecretsEmailConfigurationProvider secretsEmailConfigurationProvider,
+                                                              FromAddressExceptionLogger fromAddressExceptionLogger,
+                                                              ToAddressExceptionLogger toAddressExceptionLogger) {
         return new EmailerDetectedActionFactory(mimeMessageFactory, emailerDetectedActionLogger,
-                sender, secretsEmailConfigurationProvider);
+                sender, secretsEmailConfigurationProvider, fromAddressExceptionLogger, toAddressExceptionLogger);
+    }
+
+    @Bean
+    @Autowired
+    FromAddressExceptionLogger fromAddressExceptionLogger(Logger fromAddressExceptionLoggerLogger) {
+        return new FromAddressExceptionLogger(fromAddressExceptionLoggerLogger);
+    }
+
+    @Bean
+    @Autowired
+    ToAddressExceptionLogger toAddressExceptionLogger(Logger toAddressExceptionLoggerLogger) {
+        return new ToAddressExceptionLogger(toAddressExceptionLoggerLogger);
     }
 
     @Bean
@@ -280,11 +306,15 @@ public class SpringConfig {
     EmailerDetectedAction emailerDetectedAction(EmailerDetectedAction.MimeMessageFactory mimeMessageFactory,
                                                 Logger emailerDetectedActionLogger,
                                                 EmailerDetectedAction.Sender sender,
-                                                SecretsEmailConfigurationProvider secretsEmailConfigurationProvider) {
+                                                SecretsEmailConfigurationProvider secretsEmailConfigurationProvider,
+                                                FromAddressExceptionLogger fromAddressExceptionLogger,
+                                                ToAddressExceptionLogger toAddressExceptionLogger) {
         return new EmailerDetectedAction(mimeMessageFactory,
                 emailerDetectedActionLogger,
                 sender,
-                secretsEmailConfigurationProvider);
+                secretsEmailConfigurationProvider,
+                fromAddressExceptionLogger,
+                toAddressExceptionLogger);
     }
 
     @Bean

--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/EmailerDetectedActionFactory.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/EmailerDetectedActionFactory.java
@@ -28,20 +28,27 @@ public class EmailerDetectedActionFactory implements DetectedActionFactory {
     private final Logger emailerLogger;
     private final EmailerDetectedAction.Sender sender;
     private final SecretsEmailConfigurationProvider secretsEmailConfigurationProvider;
+    private final FromAddressExceptionLogger fromAddressExceptionLogger;
+    private final ToAddressExceptionLogger toAddressExceptionLogger;
 
     @Autowired
     public EmailerDetectedActionFactory(EmailerDetectedAction.MimeMessageFactory mimeMessageFactory,
                                         Logger emailerDetectedActionLogger,
                                         EmailerDetectedAction.Sender sender,
-                                        SecretsEmailConfigurationProvider secretsEmailConfigurationProvider) {
+                                        SecretsEmailConfigurationProvider secretsEmailConfigurationProvider,
+                                        FromAddressExceptionLogger fromAddressExceptionLogger,
+                                        ToAddressExceptionLogger toAddressExceptionLogger) {
         this.mimeMessageFactory = mimeMessageFactory;
         this.emailerLogger = emailerDetectedActionLogger;
         this.sender = sender;
         this.secretsEmailConfigurationProvider = secretsEmailConfigurationProvider;
+        this.fromAddressExceptionLogger = fromAddressExceptionLogger;
+        this.toAddressExceptionLogger = toAddressExceptionLogger;
     }
 
     @Override
     public DetectedAction create() {
-        return new EmailerDetectedAction(mimeMessageFactory, emailerLogger, sender, secretsEmailConfigurationProvider);
+        return new EmailerDetectedAction(mimeMessageFactory, emailerLogger, sender, secretsEmailConfigurationProvider,
+                fromAddressExceptionLogger, toAddressExceptionLogger);
     }
 }

--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/FromAddressExceptionLogger.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/FromAddressExceptionLogger.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.secretDetector.actions;
+
+import com.netflix.servo.util.VisibleForTesting;
+import org.slf4j.Logger;
+
+public class FromAddressExceptionLogger {
+    @VisibleForTesting
+    static final String FROM_ADDRESS_EXCEPTION_MSG = "Problem using eMail configurations: from [%s]";
+
+    private final Logger logger;
+
+    public FromAddressExceptionLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    void logError(String sFrom, Exception exception) {
+        final String message = String.format(FROM_ADDRESS_EXCEPTION_MSG, sFrom);
+        logger.error(message, exception);
+    }
+
+}

--- a/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/ToAddressExceptionLogger.java
+++ b/secret-detector/src/main/java/com/expedia/www/haystack/pipes/secretDetector/actions/ToAddressExceptionLogger.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.secretDetector.actions;
+
+import com.netflix.servo.util.VisibleForTesting;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+public class ToAddressExceptionLogger {
+    @VisibleForTesting
+    static final String TO_ADDRESS_EXCEPTION_MSG = "Problem using eMail configurations: to [%s]";
+
+    private final Logger logger;
+
+    public ToAddressExceptionLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    void logError(List<String> sTos, Exception exception) {
+        final String message = String.format(TO_ADDRESS_EXCEPTION_MSG, sTos);
+        logger.error(message, exception);
+    }
+
+}

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/SpringConfigTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/SpringConfigTest.java
@@ -27,6 +27,8 @@ import com.expedia.www.haystack.pipes.commons.health.HealthController;
 import com.expedia.www.haystack.pipes.commons.health.HealthStatusListener;
 import com.expedia.www.haystack.pipes.commons.kafka.KafkaStreamStarter;
 import com.expedia.www.haystack.pipes.secretDetector.actions.EmailerDetectedAction;
+import com.expedia.www.haystack.pipes.secretDetector.actions.FromAddressExceptionLogger;
+import com.expedia.www.haystack.pipes.secretDetector.actions.ToAddressExceptionLogger;
 import com.expedia.www.haystack.pipes.secretDetector.config.ActionsConfigurationProvider;
 import com.expedia.www.haystack.pipes.secretDetector.mains.ProtobufToDetectorAction;
 import com.netflix.servo.monitor.Counter;
@@ -127,6 +129,20 @@ public class SpringConfigTest {
         final Logger logger = springConfig.detectorActionLogger();
 
         assertEquals(DetectorAction.class.getName(), logger.getName());
+    }
+
+    @Test
+    public void testFromAddressExceptionLoggerLogger() {
+        final Logger logger = springConfig.fromAddressExceptionLoggerLogger();
+
+        assertEquals(FromAddressExceptionLogger.class.getName(), logger.getName());
+    }
+
+    @Test
+    public void testToAddressExceptionLoggerLogger() {
+        final Logger logger = springConfig.toAddressExceptionLoggerLogger();
+
+        assertEquals(ToAddressExceptionLogger.class.getName(), logger.getName());
     }
 
     @Test

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/EmailerDetectedActionMimeMessageFactoryTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/EmailerDetectedActionMimeMessageFactoryTest.java
@@ -38,13 +38,18 @@ public class EmailerDetectedActionMimeMessageFactoryTest {
     private EmailerDetectedAction.Sender mockSender;
     @Mock
     private SecretsEmailConfigurationProvider mockSecretsEmailConfigurationProvider;
+    @Mock
+    private FromAddressExceptionLogger mockFromAddressExceptionLogger;
+    @Mock
+    private ToAddressExceptionLogger mockToAddressExceptionLogger;
 
     private EmailerDetectedActionFactory emailerDetectedActionFactory;
 
     @Before
     public void setUp() {
-        emailerDetectedActionFactory = new EmailerDetectedActionFactory(
-                mockEmailerMimeMessageFactory, mockEmailerLogger, mockSender, mockSecretsEmailConfigurationProvider);
+        emailerDetectedActionFactory = new EmailerDetectedActionFactory(mockEmailerMimeMessageFactory,
+                mockEmailerLogger, mockSender, mockSecretsEmailConfigurationProvider, mockFromAddressExceptionLogger,
+                mockToAddressExceptionLogger);
     }
 
     @After

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/FromAddressExceptionLoggerTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/FromAddressExceptionLoggerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.secretDetector.actions;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static com.expedia.www.haystack.pipes.secretDetector.actions.FromAddressExceptionLogger.FROM_ADDRESS_EXCEPTION_MSG;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FromAddressExceptionLoggerTest {
+    private static final String FROM = RANDOM.nextLong() + "FROM";
+    private static final String MESSAGE = RANDOM.nextLong() + "MESSAGE";
+
+    @Mock
+    private Logger mockLogger;
+    @Mock
+    private Exception mockException;
+
+    private FromAddressExceptionLogger fromAddressExceptionLogger;
+
+    @Before
+    public void setUp() {
+        fromAddressExceptionLogger = new FromAddressExceptionLogger(mockLogger);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockException);
+    }
+
+    @Test
+    public void testLogError() {
+        when(mockException.getMessage()).thenReturn(MESSAGE);
+
+        fromAddressExceptionLogger.logError(FROM, mockException);
+
+        final String message = String.format(FROM_ADDRESS_EXCEPTION_MSG, FROM);
+        verify(mockLogger).error(message, mockException);
+    }
+
+}

--- a/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/ToAddressExceptionLoggerTest.java
+++ b/secret-detector/src/test/java/com/expedia/www/haystack/pipes/secretDetector/actions/ToAddressExceptionLoggerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.expedia.www.haystack.pipes.secretDetector.actions;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.expedia.www.haystack.pipes.commons.test.TestConstantsAndCommonCode.RANDOM;
+import static com.expedia.www.haystack.pipes.secretDetector.actions.ToAddressExceptionLogger.TO_ADDRESS_EXCEPTION_MSG;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ToAddressExceptionLoggerTest {
+    private static final List<String> TOS = Collections.singletonList(RANDOM.nextLong() + "TOS");
+    private static final String MESSAGE = RANDOM.nextLong() + "MESSAGE";
+
+    @Mock
+    private Logger mockLogger;
+    @Mock
+    private Exception mockException;
+
+    private ToAddressExceptionLogger toAddressExceptionLogger;
+
+    @Before
+    public void setUp() {
+        toAddressExceptionLogger = new ToAddressExceptionLogger(mockLogger);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(mockLogger);
+        verifyNoMoreInteractions(mockException);
+    }
+
+    @Test
+    public void testLogError() {
+        when(mockException.getMessage()).thenReturn(MESSAGE);
+
+        toAddressExceptionLogger.logError(TOS, mockException);
+
+        final String message = String.format(TO_ADDRESS_EXCEPTION_MSG, TOS);
+        verify(mockLogger).error(message, mockException);
+    }
+
+}


### PR DESCRIPTION
only be one logger.error call in FailedRecordExtractor. This is part of
the fix for https://github.com/ExpediaDotCom/haystack-pipes/issues/265.